### PR TITLE
Use NodeId to group transactions by account

### DIFF
--- a/AElf.Kernel/Concurrency/Grouper.cs
+++ b/AElf.Kernel/Concurrency/Grouper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace AElf.Kernel.Concurrency
 {
@@ -46,7 +47,7 @@ namespace AElf.Kernel.Concurrency
             }
             
             Dictionary<Hash, UnionFindNode> accountUnionSet = new Dictionary<Hash, UnionFindNode>();
-            
+
             //set up the union find set
             foreach (var accountTxList in txList.Values)
             {
@@ -63,47 +64,23 @@ namespace AElf.Kernel.Concurrency
                         toNode = new UnionFindNode();
                         accountUnionSet.Add(tx.To, toNode);
                     }
-                    
+
                     fromNode.Union(toNode);
                 }
             }
 
-            //set up the result group and init the first group
-            var groupList = new List<TransactionParallelGroup>();
-            bool firstElement = true;
-            //if two txs' account in the same set, then these two are in the same group
-            foreach (var accountTxList in txList)
-            {
-                if (firstElement)
-                {
-                    var firstGroup = new TransactionParallelGroup();
-                    firstGroup.AddAccountTxList(accountTxList);
-                    groupList.Add(firstGroup);
-                    firstElement = false;
-                }
-                else
-                {
-                    bool createNewGroup = true;
-                    foreach (var group in groupList)
-                    {
-                        if (accountUnionSet[accountTxList.Key].IsUnionedWith(accountUnionSet[group.GetOneAccountInGroup()]))
-                        {
-                            group.AddAccountTxList(accountTxList);
-                            createNewGroup = false;
-                        }
-                    }
-
-                    if (createNewGroup)
-                    {
-                        var newGroup = new TransactionParallelGroup();
-                        newGroup.AddAccountTxList(accountTxList);
-                        groupList.Add(newGroup);
-                    }
-                }
-            }
-    
-            return groupList;
-        }
+			Dictionary<int, TransactionParallelGroup> grouped = new Dictionary<int, TransactionParallelGroup>();         
+			foreach(var senderTxList in txList){
+				int nodeId = accountUnionSet[senderTxList.Key].Find().NodeId;
+				if(!grouped.TryGetValue(nodeId, out var txs)){
+					txs = new TransactionParallelGroup();
+					grouped.Add(nodeId, txs);
+                  }
+				txs.AddAccountTxList(senderTxList);
+			}
+         
+			return grouped.Values.ToList();
+       }
         
         
     }

--- a/AElf.Kernel/Concurrency/UnionFindNode.cs
+++ b/AElf.Kernel/Concurrency/UnionFindNode.cs
@@ -1,19 +1,22 @@
 ﻿using System;
+using System.Threading;
 
 namespace AElf.Kernel.Concurrency
 {
-    /// <summary>
-    /// A UnionFindNode represents a set of nodes that it is a member of.
-    /// 
-    /// You can get the unique representative node of the set a given node is in by using the Find method.
-    /// Two nodes are in the same set when their Find methods return the same representative.
-    /// The IsUnionedWith method will check if two nodes' sets are the same (i.e. the nodes have the same representative).
-    ///
-    /// You can merge the sets two nodes are in by using the Union operation.
-    /// There is no way to split sets after they have been merged.
-    /// </summary>
-    public class UnionFindNode
-    {
+	/// <summary>
+	/// A UnionFindNode represents a set of nodes that it is a member of.
+	/// 
+	/// You can get the unique representative node of the set a given node is in by using the Find method.
+	/// Two nodes are in the same set when their Find methods return the same representative.
+	/// The IsUnionedWith method will check if two nodes' sets are the same (i.e. the nodes have the same representative).
+	///
+	/// You can merge the sets two nodes are in by using the Union operation.
+	/// There is no way to split sets after they have been merged.
+	/// </summary>
+	public class UnionFindNode
+	{
+		static int nextId = 0;
+		public int NodeId { get; private set; }
         private UnionFindNode _parent;
         private uint _rank;
 
@@ -22,13 +25,14 @@ namespace AElf.Kernel.Concurrency
         /// </summary>
         public UnionFindNode() {
             _parent = this;
+			NodeId = Interlocked.Increment(ref nextId);
         }
 
         /// <summary>
         /// Returns the current representative of the set this node is in.
         /// Note that the representative is only accurate untl the next Union operation.
         /// </summary>
-        private UnionFindNode Find() {
+		public UnionFindNode Find() {
             if (!ReferenceEquals(_parent, this)) _parent = _parent.Find();
             return _parent;
         }


### PR DESCRIPTION
Removed nested for loop and use NodeId for grouping transactions by account