### PR TITLE
Fix benchmark cli exception

### DIFF
--- a/AElf.Benchmark/AElf.Benchmark.csproj
+++ b/AElf.Benchmark/AElf.Benchmark.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AElf.Benchmark.TestContract\AElf.Benchmark.TestContract.csproj" />
+    <ProjectReference Include="..\AElf.Contracts.Genesis\AElf.Contracts.Genesis.csproj" />
     <ProjectReference Include="..\AElf.Kernel.Modules.AutofacModule\AElf.Kernel.Modules.AutofacModule.csproj">
       <Project>{C7B2F451-DF68-4FBB-AEA1-020F17BB6598}</Project>
       <Name>AElf.Kernel.Modules.AutofacModule</Name>
     </ProjectReference>
-    <ProjectReference Include="..\AElf.Kernel.Tests.TestContractZero\AElf.Kernel.Tests.TestContractZero.csproj" />
     <ProjectReference Include="..\AElf.Kernel\AElf.Kernel.csproj" />
     <ProjectReference Include="..\AElf.Runtime.CSharp\AElf.Runtime.CSharp.csproj">
       <Project>{01FDA9AA-9328-449A-91CA-93424049F57D}</Project>

--- a/AElf.Benchmark/BenchmarkOptions.cs
+++ b/AElf.Benchmark/BenchmarkOptions.cs
@@ -20,7 +20,7 @@ namespace AElf.Benchmark
         [Option(Default = "AElf.Benchmark.TestContract.dll", HelpText = "The dll file name that contains the token transfer contract.")]
         public string ContractDll { get; set; }
         
-        [Option(Default = "AElf.Kernel.Tests.TestContractZero.dll", HelpText = "The dll file name that contains the contract zero.")]
+        [Option(Default = "AElf.Contracts.Genesis.dll", HelpText = "The dll file name that contains the contract zero.")]
         public string ZeroContractDll { get; set; }
         
         [Option('f', "SupportedBenchmark", Default = "evenGroup", HelpText = "The benchmark you want to run. Choose one of the following options [evenGroup] (more benchmark method is under development)")]
@@ -41,7 +41,7 @@ namespace AElf.Benchmark
         [Option(Default = "127.0.0.1", HelpText = "host of the database, default is 127.0.0.1")]
         public string DbHost { get; set; }
         
-        [Option(HelpText = "port of the database, default is 8888")]
+        [Option(Default = 8888, HelpText = "port of the database, default is 8888")]
         public int DbPort { get; set; }
         
         public DatabaseConfig DatabaseConfig

--- a/AElf.Benchmark/BenchmarkTps.cs
+++ b/AElf.Benchmark/BenchmarkTps.cs
@@ -17,7 +17,6 @@ using AElf.Kernel.Managers;
 using AElf.Kernel.Modules.AutofacModule;
 using AElf.Kernel.Services;
 using AElf.Kernel.Storages;
-using AElf.Kernel.Tests;
 using AElf.Runtime.CSharp;
 using AElf.Sdk.CSharp;
 using AElf.Types.CSharp;

--- a/AElf.Benchmark/Program.cs
+++ b/AElf.Benchmark/Program.cs
@@ -116,7 +116,7 @@ namespace AElf.Benchmark
                     await benchmarkTps.BenchmarkEvenGroup();
                 }
 
-                Console.WriteLine("Press any key to continue ");
+                Console.WriteLine("\n\nPress any key to continue ");
                 Console.ReadKey();
             }
         }

--- a/AElf.Benchmark/Program.cs
+++ b/AElf.Benchmark/Program.cs
@@ -37,6 +37,18 @@ namespace AElf.Benchmark
                 return;
             }
 
+            if (opts.SdkDir == null)
+            {
+                opts.SdkDir = Directory.GetCurrentDirectory();
+                Console.WriteLine("No Sdk directory in arg, choose current directory: " + opts.SdkDir);
+            }
+            
+            if (opts.DllDir == null)
+            {
+                opts.DllDir = Directory.GetCurrentDirectory();
+                Console.WriteLine("No dll directory in arg, choose current directory: " + opts.DllDir);
+            }
+
             if (!Directory.Exists(System.IO.Path.GetFullPath(opts.SdkDir)))
             {
                 Console.WriteLine("directory " + System.IO.Path.GetFullPath(opts.SdkDir) + " not exist");
@@ -103,6 +115,8 @@ namespace AElf.Benchmark
                 {
                     await benchmarkTps.BenchmarkEvenGroup();
                 }
+
+                Console.WriteLine("Press any key to continue ");
                 Console.ReadKey();
             }
         }


### PR DESCRIPTION
1. Fix the error that uses AElf.Kernel.Tests.TestContractZero.dll as default
2. improve the exception handling in the command line of benchmark