### PR TITLE
Fix the concurrency issue with executive being put back multiple times

### DIFF
--- a/AElf.Execution/Execution/Worker.cs
+++ b/AElf.Execution/Execution/Worker.cs
@@ -244,19 +244,12 @@ namespace AElf.Execution
             {
                 executive = await _servicePack.SmartContractService
                     .GetExecutiveAsync(transaction.To, chainContext.ChainId);
-                try
-                {
-                    executive.SetDataCache(stateCache);
 
-                    await executive.SetTransactionContext(txCtxt).Apply(false);
-                    trace.Logs.AddRange(txCtxt.Trace.FlattenedLogs);
-                    // TODO: Check run results / logs etc.
-                }
-                finally
-                {
-                    await _servicePack.SmartContractService.PutExecutiveAsync(transaction.To, executive);    
-                }
+                executive.SetDataCache(stateCache);
 
+                await executive.SetTransactionContext(txCtxt).Apply(false);
+                trace.Logs.AddRange(txCtxt.Trace.FlattenedLogs);
+                // TODO: Check run results / logs etc.
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Executive cannot be used by concurrently to process multiple transactions.