### PR TITLE
Put sdk cache in runner instead of context

### DIFF
--- a/AElf.Runtime.CSharp.Tests/ContractCodeLoadContextTest.cs
+++ b/AElf.Runtime.CSharp.Tests/ContractCodeLoadContextTest.cs
@@ -16,7 +16,7 @@ namespace AElf.Runtime.CSharp.Tests
         private ContractCodeLoadContext _loadContext;
         public ContractCodeLoadContextTest()
         {
-            _loadContext = new ContractCodeLoadContext(System.IO.Path.GetFullPath(_apiDllDirectory));
+            _loadContext = new ContractCodeLoadContext(System.IO.Path.GetFullPath(_apiDllDirectory), null);
         }
 
         [Fact]

--- a/AElf.Runtime.CSharp/SmartContractRunner.cs
+++ b/AElf.Runtime.CSharp/SmartContractRunner.cs
@@ -1,5 +1,6 @@
 ﻿﻿using System;
-using System.Collections.Generic;
+ using System.Collections.Concurrent;
+ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -21,6 +22,7 @@ namespace AElf.Runtime.CSharp
 {
     public class SmartContractRunner : ISmartContractRunner
     {
+        private readonly ConcurrentDictionary<AssemblyName, MemoryStream> _cachedSdkStreams = new ConcurrentDictionary<AssemblyName, MemoryStream>();
         private readonly string _sdkDir;
         private readonly AssemblyChecker _assemblyChecker;
 
@@ -41,7 +43,7 @@ namespace AElf.Runtime.CSharp
         private ContractCodeLoadContext GetLoadContext()
         {
             // To make sure each smart contract resides in an isolated context with an Api singleton
-            return new ContractCodeLoadContext(_sdkDir);
+            return new ContractCodeLoadContext(_sdkDir, _cachedSdkStreams);
         }
 
         public async Task<IExecutive> RunAsync(SmartContractRegistration reg)


### PR DESCRIPTION
SDK code cache should be put on runner instead of context as context is not shared