### PR TITLE
Fix Null Chain ID in data provider

### DIFF
--- a/AElf.SmartContract/SmartContractService.cs
+++ b/AElf.SmartContract/SmartContractService.cs
@@ -58,6 +58,8 @@ namespace AElf.SmartContract
                 throw new NotSupportedException($"Runner for category {reg.Category} is not registered.");
             }
 
+            _stateDictator.ChainId = chainId;
+
             // get account dataprovider
             var dataProvider = _stateDictator.GetAccountDataProvider(contractAddress).GetDataProvider();
 


### PR DESCRIPTION
If the SmartContractService is used in a Worker (remote machine), the ChainId in StateDictator will not be set. So we need to set it when getting executive.