### PR TITLE
Fix memory usage

### DIFF
--- a/AElf.ABI.CSharp/Generator.cs
+++ b/AElf.ABI.CSharp/Generator.cs
@@ -13,22 +13,23 @@ namespace AElf.ABI.CSharp
         public static Module GetABIModule(byte[] code, string name = null)
         {
             var module = new Module();
-            var monoModule = ModuleDefinition.ReadModule(new MemoryStream(code));
-
-            Container container = new Container("AElf.Sdk.CSharp.CSharpSmartContract", "AElf.Sdk.CSharp.Event",
-                typeof(UserType).FullName);
-            foreach (var t in monoModule.GetTypes())
+            using (var monoModule = ModuleDefinition.ReadModule(new MemoryStream(code)))
             {
-                container.AddType(t);
-            }
+                Container container = new Container("AElf.Sdk.CSharp.CSharpSmartContract", "AElf.Sdk.CSharp.Event",
+                    typeof(UserType).FullName);
+                foreach (var t in monoModule.GetTypes())
+                {
+                    container.AddType(t);
+                }
             
-            var contractTypePath = container.GetSmartContractTypePath(name);
-            module.Name = name ?? contractTypePath.Last().FullName;
-            module.Methods.AddRange(GetMethods(contractTypePath));
-            module.Events.AddRange(GetEvents(container));
-            module.Types_.AddRange(GetTypes(container));
+                var contractTypePath = container.GetSmartContractTypePath(name);
+                module.Name = name ?? contractTypePath.Last().FullName;
+                module.Methods.AddRange(GetMethods(contractTypePath));
+                module.Events.AddRange(GetEvents(container));
+                module.Types_.AddRange(GetTypes(container));
 
-            return module;
+                return module;                
+            }
         }
 
         private static IEnumerable<Method> GetMethods(IEnumerable<TypeDefinition> contractTypePath)

--- a/AElf.SmartContract/ISmartContractService.cs
+++ b/AElf.SmartContract/ISmartContractService.cs
@@ -19,7 +19,6 @@ namespace AElf.SmartContract
         /// <param name="isPrivileged">Whether the contract is a privileged (system) one.</param>
         /// <returns></returns>
         Task DeployContractAsync(Hash chainId, Hash contractAddress, SmartContractRegistration registration, bool isPrivileged);
-        Type GetContractType(SmartContractRegistration registration);
         Task<IMessage> GetAbiAsync(Hash account, string name = null);
         
         /// <summary>

--- a/AElf.SmartContract/SmartContractService.cs
+++ b/AElf.SmartContract/SmartContractService.cs
@@ -88,7 +88,7 @@ namespace AElf.SmartContract
             await Task.CompletedTask;
         }
 
-        public Type GetContractType(SmartContractRegistration registration)
+        private Type GetContractType(SmartContractRegistration registration)
         {
             var runner = _smartContractRunnerFactory.GetRunner(registration.Category);
             if (runner == null)


### PR DESCRIPTION
Fix #471 

get_tx_result calls GetTransactionParameters which indirectly uses GetContractType in SmartContractRunner. Every time this method is invoked, the code is loaded again to get the type. The memory keeps on going up as the loaded type cannot be unloaded.