### PR TITLE
Fix some bugs in TxHub

### DIFF
--- a/AElf.Kernel.Types/Protobuf/Proto/kernel.proto
+++ b/AElf.Kernel.Types/Protobuf/Proto/kernel.proto
@@ -41,6 +41,7 @@ message TransactionReceipt {
         RefBlockValid = 1;
         RefBlockInvalid = -1;
         RefBlockExpired = -2;
+        FutureRefBlock = -3;
     }
     Hash TransactionId = 1;
     Transaction Transaction = 2;

--- a/AElf.Miner/TxMemPool/RefBlockExceptions/FutureRefBlockException.cs
+++ b/AElf.Miner/TxMemPool/RefBlockExceptions/FutureRefBlockException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace AElf.Miner.TxMemPool.RefBlockExceptions
+{
+    public class FutureRefBlockException : Exception
+    {
+        public FutureRefBlockException()
+        {
+        }
+
+        public FutureRefBlockException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/AElf.Miner/TxMemPool/TxHub.cs
+++ b/AElf.Miner/TxMemPool/TxHub.cs
@@ -59,15 +59,14 @@ namespace AElf.Miner.TxMemPool
             _chainService = chainService;
             _signatureVerifier = signatureVerifier;
             _refBlockValidator = refBlockValidator;
-
         }
 
         public void Initialize()
         {
             MessageHub.Instance.Subscribe<TransactionsExecuted>(OnTransactionsExecuted);
-            MessageHub.Instance.Subscribe<BlockHeader>(OnNewBlockHeader);
+            MessageHub.Instance.Subscribe<BlockHeader>(async h => await OnNewBlockHeader(h));
             MessageHub.Instance.Subscribe<BranchRolledBack>(async branch =>
-                await OnBranchRolledBack(branch.Blocks).ConfigureAwait(false));            
+                await OnBranchRolledBack(branch.Blocks).ConfigureAwait(false));
         }
 
         public void Start()
@@ -127,6 +126,7 @@ namespace AElf.Miner.TxMemPool
                 if (!_allTxns.TryGetValue(txn.GetHash(), out var tr))
                 {
                     tr = new TransactionReceipt(txn);
+                    _allTxns.TryAdd(tr.TransactionId, tr);
                 }
 
                 VerifySignature(tr);
@@ -144,7 +144,7 @@ namespace AElf.Miner.TxMemPool
             {
                 tr = await _receiptManager.GetReceiptAsync(txId);
             }
-            
+
             return tr;
         }
 
@@ -190,7 +190,8 @@ namespace AElf.Miner.TxMemPool
 
         private async Task ValidateRefBlock(TransactionReceipt tr)
         {
-            if (tr.RefBlockSt != TransactionReceipt.Types.RefBlockStatus.UnknownRefBlockStatus)
+            if (tr.RefBlockSt != TransactionReceipt.Types.RefBlockStatus.UnknownRefBlockStatus &&
+                tr.RefBlockSt != TransactionReceipt.Types.RefBlockStatus.FutureRefBlock)
             {
                 return;
             }
@@ -199,6 +200,10 @@ namespace AElf.Miner.TxMemPool
             {
                 await _refBlockValidator.ValidateAsync(tr.Transaction);
                 tr.RefBlockSt = TransactionReceipt.Types.RefBlockStatus.RefBlockValid;
+            }
+            catch (FutureRefBlockException)
+            {
+                tr.RefBlockSt = TransactionReceipt.Types.RefBlockStatus.FutureRefBlock;
             }
             catch (RefBlockInvalidException)
             {
@@ -254,10 +259,10 @@ namespace AElf.Miner.TxMemPool
         }
 
         // Render transactions to expire, and purge old transactions (RefBlockValidPeriod + some buffer)
-        private void OnNewBlockHeader(BlockHeader blockHeader)
+        private async Task OnNewBlockHeader(BlockHeader blockHeader)
         {
             // TODO: Handle LIB
-            if (blockHeader.Index != (CurHeight + 1) && CurHeight != 0)
+            if (blockHeader.Index != (CurHeight + 1) && CurHeight != GlobalConfig.GenesisBlockHeight)
             {
                 throw new Exception("Invalid block index.");
             }
@@ -289,6 +294,13 @@ namespace AElf.Miner.TxMemPool
                 {
                     _allTxns.TryRemove(tr.Key, out _);
                 }
+            }
+
+            // Re-validate FutureRefBlock transactions
+            foreach (var tr in _allTxns.Values.Where(x =>
+                x.RefBlockSt == TransactionReceipt.Types.RefBlockStatus.FutureRefBlock))
+            {
+                await ValidateRefBlock(tr);
             }
         }
 

--- a/AElf.Miner/TxMemPool/TxHub.cs
+++ b/AElf.Miner/TxMemPool/TxHub.cs
@@ -275,6 +275,7 @@ namespace AElf.Miner.TxMemPool
                 var expired = _allTxns.Where(tr =>
                     tr.Value.Status == TransactionReceipt.Types.TransactionStatus.UnknownTransactionStatus
                     && tr.Value.RefBlockSt != TransactionReceipt.Types.RefBlockStatus.RefBlockExpired
+                    && CurHeight > tr.Value.Transaction.RefBlockNumber
                     && CurHeight - tr.Value.Transaction.RefBlockNumber > GlobalConfig.ReferenceBlockValidPeriod
                 );
                 foreach (var tr in expired)

--- a/AElf.Miner/TxMemPool/TxHub.cs
+++ b/AElf.Miner/TxMemPool/TxHub.cs
@@ -262,9 +262,9 @@ namespace AElf.Miner.TxMemPool
         private async Task OnNewBlockHeader(BlockHeader blockHeader)
         {
             // TODO: Handle LIB
-            if (blockHeader.Index != (CurHeight + 1) && CurHeight != GlobalConfig.GenesisBlockHeight)
+            if (blockHeader.Index > (CurHeight + 1) && CurHeight != GlobalConfig.GenesisBlockHeight)
             {
-                throw new Exception("Invalid block index.");
+                throw new Exception($"Invalid block index {blockHeader.Index} but current height is {CurHeight}.");
             }
 
             _curHeight = blockHeader.Index;

--- a/AElf.Miner/TxMemPool/TxRefBlockValidator.cs
+++ b/AElf.Miner/TxMemPool/TxRefBlockValidator.cs
@@ -48,7 +48,7 @@ namespace AElf.Miner.TxMemPool
             var curHeight = _canonicalBlockHashCache.CurrentHeight;
             if (tx.RefBlockNumber > curHeight && curHeight > GlobalConfig.GenesisBlockHeight)
             {
-                throw  new RefBlockInvalidException();
+                throw  new FutureRefBlockException();
             }
 
             if (curHeight > GlobalConfig.ReferenceBlockValidPeriod + GlobalConfig.GenesisBlockHeight &&


### PR DESCRIPTION
1. FutureRefBlock
1. Unknown txn in syncing block need to be added to TxHub
1. FutureRefBlock is expired by ulong subtraction overflow
1. CurHeight should also be valid for a restarted node (because blockchain height is updated before TxHub handles new block event and retrieves the CurHeight from database)