### PR TITLE
Call TxHub's OnNewBlock directly

### DIFF
--- a/AElf.Miner/Miner/Miner.cs
+++ b/AElf.Miner/Miner/Miner.cs
@@ -133,6 +133,8 @@ namespace AElf.Miner.Miner
                 // insert to db
                 Update(executed, results, block, parentChainBlockInfo, genTx);
 
+                await _txHub.OnNewBlock((Block)block);
+
                 MessageHub.Instance.Publish(new BlockMined(block));
 
                 stopwatch.Stop();

--- a/AElf.Miner/TxMemPool/ITxHub.cs
+++ b/AElf.Miner/TxMemPool/ITxHub.cs
@@ -26,5 +26,7 @@ namespace AElf.Miner.TxMemPool
         /// close transaction pool
         /// </summary>
         Task Stop();
+
+        Task OnNewBlock(Block block);
     }
 }

--- a/AElf.Miner/TxMemPool/TxHub.cs
+++ b/AElf.Miner/TxMemPool/TxHub.cs
@@ -66,8 +66,6 @@ namespace AElf.Miner.TxMemPool
 
         public void Initialize()
         {
-            MessageHub.Instance.Subscribe<BlockMined>(async b => { await OnNewBlock((Block) b.Block); });
-            MessageHub.Instance.Subscribe<BlockExecuted>(async b => { await OnNewBlock((Block) b.Block); });
             MessageHub.Instance.Subscribe<BranchRolledBack>(async branch =>
                 await OnBranchRolledBack(branch.Blocks).ConfigureAwait(false));
         }
@@ -310,7 +308,7 @@ namespace AElf.Miner.TxMemPool
         }
 
         // Render transactions to expire, and purge old transactions (RefBlockValidPeriod + some buffer)
-        private async Task OnNewBlock(Block block)
+        public async Task OnNewBlock(Block block)
         {
             var blockHeader = block.Header;
             // TODO: Handle LIB

--- a/AElf.Synchronization/BlockExecution/BlockExecutor.cs
+++ b/AElf.Synchronization/BlockExecution/BlockExecutor.cs
@@ -102,6 +102,7 @@ namespace AElf.Synchronization.BlockExecution
                 await AppendBlock(block);
                 await InsertTxs(readyTxs, txnRes, block);
 
+                await _txHub.OnNewBlock((Block)block);
                 MessageHub.Instance.Publish(new ExecutionStateChanged(false));
 
 


### PR DESCRIPTION
Previously TxHub's OnNewBlock is called indirectly via BlockExecuted and BlockMined event.

It poses one issue:
* Some other actions triggered by BlockExecuted enables Mining
* In TxHub's OnNewBlock, executed transactions will be marked
* If Mining starts before executed transactions are all marked, already executed transactions (not yet marked) may be sent for execution again. The problem will be found by peer node trying to sync the block with already executed transactions which can not be executed due to already executed.