### PR TITLE
Optional callback after successful net send.

### DIFF
--- a/AElf.Network.Tests/PeerTests.cs
+++ b/AElf.Network.Tests/PeerTests.cs
@@ -57,7 +57,7 @@ namespace AElf.Network.Tests
             Peer p = new Peer(new TcpClient(), reader.Object, messageWritter.Object, peerPort, kp, 0);
 
             Message authMessage = null;
-            messageWritter.Setup(w => w.EnqueueMessage(It.IsAny<Message>())).Callback<Message>(m => authMessage = m);
+            messageWritter.Setup(w => w.EnqueueMessage(It.IsAny<Message>(), It.IsAny<Action<Message>>())).Callback<Message, Action<Message>>((m, a) => authMessage = m);
             
             p.Start();
             

--- a/AElf.Network/Connection/IMessageWriter.cs
+++ b/AElf.Network/Connection/IMessageWriter.cs
@@ -5,7 +5,7 @@ namespace AElf.Network.Connection
     public interface IMessageWriter : IDisposable
     {
         void Start();
-        void EnqueueMessage(Message p);
+        void EnqueueMessage(Message p, Action<Message> successCallback = null);
 
         void Close();
     }

--- a/AElf.Network/Peers/IPeer.cs
+++ b/AElf.Network/Peers/IPeer.cs
@@ -23,7 +23,7 @@ namespace AElf.Network.Peers
         
         NodeData DistantNodeData { get; }
         byte[] DistantNodeAddress { get; }
-        void EnqueueOutgoing(Message msg, ITimedRequest associatedRequest = null);
+        void EnqueueOutgoing(Message msg, Action<Message> successCallback = null);
         void Sync(int start, int target);
         void OnNewBlockAccepted(IBlock block);
 

--- a/AElf.Network/Peers/Peer.Sync.cs
+++ b/AElf.Network/Peers/Peer.Sync.cs
@@ -88,7 +88,7 @@ namespace AElf.Network.Peers
         {
             if (a?.Id == null)
             {
-                _logger?.Error($"Peer {this} announcement or its id is null.");
+                _logger?.Error($"[{this}] announcement or its id is null.");
                 return;
             }
             
@@ -106,16 +106,16 @@ namespace AElf.Network.Peers
                 if (a.Height <= _peerHeight)
                 {
                     // todo just log for now, but this is probably a protocol error.
-                    _logger?.Warn($"Peer {this} current know heigth: {_peerHeight} announcement height {a.Height}.");
+                    _logger?.Warn($"[{this}] current know heigth: {_peerHeight} announcement height {a.Height}.");
                 }
             
                 _peerHeight = a.Height;
             
-                _logger?.Trace($"Peer {this} height increased: {_peerHeight}.");
+                _logger?.Trace($"[{this}] height increased: {_peerHeight}.");
             }
             catch (Exception e)
             {
-                _logger?.Error(e, $"Peer {this} error processing announcement.");
+                _logger?.Error(e, $"[{this}] error processing announcement.");
             }
         }
 
@@ -163,7 +163,7 @@ namespace AElf.Network.Peers
                 {
                     if (blockHeight >= _syncTarget)
                     {
-                        _logger?.Info($"Peer {this} sync finished at {_syncTarget}.");
+                        _logger?.Info($"[{this}] sync finished at {_syncTarget}.");
                         
                         EndSync();
                     }
@@ -216,7 +216,7 @@ namespace AElf.Network.Peers
 
             if (message.Payload == null)
             {
-                _logger?.Warn($"Peer {this} request for block at height {index} failed because payload is null.");
+                _logger?.Warn($"[{this}] request for block at height {index} failed because payload is null.");
                 return;   
             }
             
@@ -231,7 +231,7 @@ namespace AElf.Network.Peers
 
             if (message.Payload == null)
             {
-                _logger?.Warn($"Peer {this} request for block with id {id.ToHex()} failed because payload is null.");
+                _logger?.Warn($"[{this}] request for block with id {id.ToHex()} failed because payload is null.");
                 return;
             }
 
@@ -255,14 +255,14 @@ namespace AElf.Network.Peers
                 _logger?.Trace($"[{this}] Block request sent {{ hash: {blockRequest.Id.ToHex()} }}");
             });
             
-            _logger?.Trace($"Peer {this} block request enqueued {blockRequest}.");
+            _logger?.Trace($"[{this}] block request enqueued {blockRequest}.");
         }
 
         private void TimedRequestOnRequestTimedOut(object sender, EventArgs e)
         {
             if (sender is TimedBlockRequest req)
             {
-                _logger?.Warn($"Peer {this} failed timed request {req}");
+                _logger?.Warn($"[{this}] failed timed request {req}");
                 
                 if (req.CurrentPeerRetries < MaxRequestRetries)
                 {
@@ -271,7 +271,7 @@ namespace AElf.Network.Peers
                         return;
                     }
                     
-                    _logger?.Debug($"Peer {this} try again {req}.");
+                    _logger?.Debug($"[{this}] try again {req}.");
                     
                     EnqueueOutgoing(req.Message, (_) =>
                     {
@@ -290,7 +290,7 @@ namespace AElf.Network.Peers
                         _blockRequests.RemoveAll(b => (b.IsById && b.Id.BytesEqual(req.Id)) || (!b.IsById && b.Height == req.Height));
                     }
                     
-                    _logger?.Warn($"Peer {this} request failed {req}.");
+                    _logger?.Warn($"[{this}] request failed {req}.");
                     
                     req.RequestTimedOut -= TimedRequestOnRequestTimedOut;
                 }

--- a/AElf.Network/Peers/Peer.cs
+++ b/AElf.Network/Peers/Peer.cs
@@ -404,10 +404,10 @@ namespace AElf.Network.Peers
         /// <summary>
         /// Sends the provided message to the peer.
         /// </summary>
-        /// <param name="data"></param>
         /// <param name="msg"></param>
+        /// <param name="successCallback"></param>
         /// <returns></returns>
-        public void EnqueueOutgoing(Message msg, ITimedRequest associatedRequest = null)
+        public void EnqueueOutgoing(Message msg, Action<Message> successCallback = null)
         {
             try
             {
@@ -421,15 +421,8 @@ namespace AElf.Network.Peers
                     _logger?.Warn($"Peer {DistantNodeData?.IpAddress} : {DistantNodeData?.Port} - Null stream while sending");
                     return;
                 }
-
-                // last check for cancelation
-                if (associatedRequest != null && associatedRequest.IsCanceled)
-                    return;
-
-                _messageWriter.EnqueueMessage(msg);
-
-                // todo should be propagated lower, after the real write
-                associatedRequest?.Start();
+                
+                _messageWriter.EnqueueMessage(msg, successCallback);
             }
             catch (Exception e)
             {

--- a/AElf.Node/Protocol/NetworkManager.cs
+++ b/AElf.Node/Protocol/NetworkManager.cs
@@ -472,9 +472,10 @@ namespace AElf.Node.Protocol
                     req.Id = args.Message.Id;
 
                 // Send response
-                args.Peer.EnqueueOutgoing(req);
-
-                _logger?.Debug($"Send block {b.BlockHashToHex} to {args.Peer}");
+                args.Peer.EnqueueOutgoing(req, (_) =>
+                {
+                    _logger?.Debug($"Block sent {{ hash: {b.BlockHashToHex}, to: {args.Peer} }}");
+                });
             }
             catch (Exception e)
             {

--- a/AElf.Node/Protocol/NetworkManager.cs
+++ b/AElf.Node/Protocol/NetworkManager.cs
@@ -381,14 +381,6 @@ namespace AElf.Node.Protocol
 
             AElfProtocolMsgType msgType = (AElfProtocolMsgType) args.Message.Type;
 
-            Stopwatch s = null;
-
-            if (msgType == AElfProtocolMsgType.Block || msgType == AElfProtocolMsgType.RequestBlock)
-            {
-                s = Stopwatch.StartNew();
-                _logger?.Trace($"Processing job ({msgType})");
-            }
-            
             switch (msgType)
             {
                 case AElfProtocolMsgType.Announcement:
@@ -410,12 +402,6 @@ namespace AElf.Node.Protocol
                 case AElfProtocolMsgType.HeaderRequest:
                     await HandleHeaderRequest(args);
                     break;
-            }
-
-            if (msgType == AElfProtocolMsgType.Block || msgType == AElfProtocolMsgType.RequestBlock)
-            {
-                s?.Stop();
-                _logger?.Trace($"Finished processing job ({msgType}) - duration: {s.ElapsedMilliseconds} ms");
             }
         }
 


### PR DESCRIPTION
Optional callback after successful net send: better for starting the request timers and logging at the exact end of the write.