### PR TITLE
Fix node sync up

### DIFF
--- a/AElf.Network/Peers/Peer.Sync.cs
+++ b/AElf.Network/Peers/Peer.Sync.cs
@@ -37,12 +37,12 @@ namespace AElf.Network.Peers
         public bool IsSyncingHistory => SyncTarget != 0;
 
         /// <summary>
-        /// When syncing an annoucements, this is the current one.
+        /// When syncing an announcements, this is the current one.
         /// </summary>
         public Announce SyncedAnnouncement { get; private set; }
 
         /// <summary>
-        /// True if syncing an annoucement.
+        /// True if syncing an announcement.
         /// </summary>
         public bool IsSyncingAnnounced => SyncedAnnouncement != null;
 
@@ -109,7 +109,7 @@ namespace AElf.Network.Peers
             
             _logger?.Debug($"[{this}] Syncing to height {SyncTarget}.");
 
-            // request 
+            // request first
             RequestBlockByIndex(CurrentlyRequestedHeight);
 
             MessageHub.Instance.Publish(new ReceivingHistoryBlocksChanged(true));
@@ -119,18 +119,27 @@ namespace AElf.Network.Peers
         /// This method will request the next block based on the current value of <see cref="CurrentlyRequestedHeight"/>.
         /// If target was reached, the state is reset and the method returns false.
         /// </summary>
-        /// <returns>Returns weither or no this call has completed the sync.</returns>
+        /// <returns>Returns whether or no this call has completed the sync.</returns>
         public bool SyncNextHistory()
         {
             if (CurrentlyRequestedHeight == SyncTarget)
             {
+                // Clean any announcements that are lower than current height
+                CleanAnnouncements(SyncTarget);
+                
                 if (_announcements.Any())
                 {
-                    var aa = _announcements.OrderBy(a => a.Height).FirstOrDefault();
-                    if (aa != null && aa.Height != SyncTarget+1)
-                        _logger?.Warn($"[{this}] We're missing a block, first announce {aa.Height} sync target {SyncTarget}");
-                    else
-                        _logger?.Debug($"[{this}] All synced : next {aa?.Height} sync target {SyncTarget}");
+                    var next = _announcements.OrderBy(a => a.Height).FirstOrDefault();
+
+                    if (next != null && next.Height != SyncTarget + 1)
+                    {
+                        // Some announcements are higher than the current height
+                        _logger?.Warn($"[{this}] Blocks missing: syncing from {SyncTarget} to sync target {next.Height}");
+                        
+                        SyncToHeight(SyncTarget+1, next.Height-1);
+
+                        return true;
+                    }
                 }
                 
                 SyncTarget = 0;
@@ -172,7 +181,7 @@ namespace AElf.Network.Peers
         public bool SyncNextAnnouncement()
         {
             if (!IsSyncingAnnounced && !_announcements.Any())
-                throw new InvalidOperationException($"Call to {nameof(SyncNextAnnouncement)} with no stashed annoucements.");
+                throw new InvalidOperationException($"Call to {nameof(SyncNextAnnouncement)} with no stashed announcements.");
 
             if (!_announcements.Any())
             {
@@ -180,9 +189,9 @@ namespace AElf.Network.Peers
                 return false;
             }
 
-            var nextAnouncement = _announcements.OrderBy(a => a.Height).First();
+            var nextAnnouncement = _announcements.OrderBy(a => a.Height).First();
 
-            SyncedAnnouncement = nextAnouncement;
+            SyncedAnnouncement = nextAnnouncement;
             _announcements.Remove(SyncedAnnouncement);
 
             RequestBlockById(SyncedAnnouncement.Id.ToByteArray(), SyncedAnnouncement.Height);
@@ -321,7 +330,7 @@ namespace AElf.Network.Peers
 
                     EnqueueOutgoing(req.Message, (_) =>
                     {
-                        // last check for cancelation
+                        // last check for cancellation
                         if (req.IsCanceled)
                             return;
 

--- a/AElf.Node/Protocol/NetworkManager.cs
+++ b/AElf.Node/Protocol/NetworkManager.cs
@@ -16,10 +16,8 @@ using AElf.Network.Eventing;
 using AElf.Network.Peers;
 using AElf.Node.AElfChain;
 using AElf.Node.EventMessages;
-using AElf.Synchronization.BlockExecution;
 using AElf.Synchronization.BlockSynchronization;
 using AElf.Synchronization.EventMessages;
-using DotNetty.Common;
 using Easy.MessageHub;
 using Google.Protobuf;
 using NLog;
@@ -32,13 +30,9 @@ namespace AElf.Node.Protocol
     {
         #region Settings
 
-        // todo better detection 
-        // public const int JobQueueWarningLimit = 1000;
-
         public const int DefaultHeaderRequestCount = 3;
         public const int DefaultMaxBlockHistory = 15;
         public const int DefaultMaxTransactionHistory = 20;
-        public const int DefaultBlockRequestCount = 10;
 
         public const int DefaultRequestTimeout = 2000;
         public const int DefaultRequestMaxRetry = TimeoutRequest.DefaultMaxRetry;
@@ -70,8 +64,6 @@ namespace AElf.Node.Protocol
         internal int LocalHeight;
 
         internal int UnlinkableHeaderIndex;
-
-        private int _blockRequestedCount;
         
         private readonly object _syncLock = new object();
 
@@ -185,11 +177,6 @@ namespace AElf.Node.Protocol
                 
                 lock (_syncLock)
                 {
-                    if (_blockRequestedCount > 0)
-                    {
-                        _blockRequestedCount--;
-                    }
-
                     if (CurrentSyncSource == null)
                     {
                         _logger?.Warn("Unexpected situation, executed a block but no peer is currently syncing.");
@@ -200,21 +187,14 @@ namespace AElf.Node.Protocol
                     }
                     else if (CurrentSyncSource.IsSyncingHistory)
                     {
-                        bool hasReqNext =false;
-
-                        for (; _blockRequestedCount < DefaultBlockRequestCount; _blockRequestedCount++)
-                        {
-                            hasReqNext = CurrentSyncSource.SyncNextHistory();
-                            if(!hasReqNext)
-                                break;
-                        }
+                        if ((int)blockHeight != CurrentSyncSource.CurrentlyRequestedHeight)
+                            _logger?.Warn($"{CurrentSyncSource} unexpected situation, the block executed was not the exepected height.");
+                    
+                        bool hasReqNext = CurrentSyncSource.SyncNextHistory();
 
                         if (hasReqNext)
-                        {
-                            _logger?.Trace($"Request Block paused, blockRequestedCount {_blockRequestedCount} ");
                             return;
-                        }
-
+                    
                         _logger?.Trace($"{CurrentSyncSource} history blocks synced, local height {LocalHeight}.");
                     
                         // If this peer still has announcements and the next one is the next block we need.
@@ -437,17 +417,6 @@ namespace AElf.Node.Protocol
             // Try and find a peer with an anouncement that corresponds to the next block we need.
             foreach (var p in _peers.Where(p => p.AnyStashed && p != oldSyncSource))
             {
-                if (p.KnownHeight > LocalHeight)
-                {
-                    CurrentSyncSource = p;
-                    CurrentSyncSource.SyncToHeight(LocalHeight + 1, p.KnownHeight);
-                    
-                    FireSyncStateChanged(true);
-                    _logger?.Debug($"Sync History with {p}.");
-                    
-                    return;
-                }
-                
                 if (p.SyncNextAnnouncement())
                 {
                     CurrentSyncSource = p;
@@ -556,12 +525,6 @@ namespace AElf.Node.Protocol
                     else
                     {
                         _peers.Remove(peer.Peer);
-
-//                        if (_peers.Count <= 0)
-//                        {
-//                            OnMinorityForkDetected();
-//                            return;
-//                        }
 
                         lock (_syncLock)
                         {


### PR DESCRIPTION
- Peer.IsSyncingHistory has been reverted to its original meaning. 
- The blocks are, for now, not requested in parallel. 
- Issue to be re-implemented: during normal sync, a failed request needs to trigger a sync to someone else.
- Fix init sync when target is lower than first announce (sync up to the lowest announce height).