### PR TITLE
DPoS consensus contract converted to use sdk2

### DIFF
--- a/AElf.Contracts.Consensus.DPoS2/AElf.Contracts.Consensus.DPoS2.csproj
+++ b/AElf.Contracts.Consensus.DPoS2/AElf.Contracts.Consensus.DPoS2.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\AElf.Kernel.Types\AElf.Kernel.Types.csproj" />
+      <ProjectReference Include="..\AElf.Sdk.CSharp2\AElf.Sdk.CSharp2.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/AElf.Contracts.Consensus.DPoS2/Config.cs
+++ b/AElf.Contracts.Consensus.DPoS2/Config.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using AElf.Common;
+
+namespace AElf.Contracts.Consensus.DPoS
+{
+    public static class Config
+    {
+        public static List<string> Aliases => new List<string>
+        {
+            "YQ", "SM", "WK", "CP", "PG", 
+            "SC", "ZX", "ZY", "YS", "MH", 
+            "ZZ", "ZA", "GL", "LN", "DW",
+            "BB", "MM", "DZ", "JJ", "DD"
+        };
+
+        public static int InitialWaitingMilliseconds = 10_000;
+
+        public static ulong GetDividendsForEveryMiner(ulong minedBlocks)
+        {
+            return (ulong) (minedBlocks * GlobalConfig.ElfTokenPerBlock * GlobalConfig.DividendsForEveryMinerRatio /
+                            GlobalConfig.BlockProducerNumber);
+        }
+
+        public static ulong GetDividendsForTicketsCount(ulong minedBlocks)
+        {
+            return (ulong) (minedBlocks * GlobalConfig.ElfTokenPerBlock * GlobalConfig.DividendsForTicketsCountRatio);
+        }
+        
+        public static ulong GetDividendsForReappointment(ulong minedBlocks)
+        {
+            return (ulong) (minedBlocks * GlobalConfig.ElfTokenPerBlock * GlobalConfig.DividendsForReappointmentRatio);
+        }
+        
+        public static ulong GetDividendsForBackupNodes(ulong minedBlocks)
+        {
+            return (ulong) (minedBlocks * GlobalConfig.ElfTokenPerBlock * GlobalConfig.DividendsForBackupNodesRatio);
+        }
+
+        public static ulong GetDividendsForVoters(ulong minedBlocks)
+        {
+            return (ulong) (minedBlocks * GlobalConfig.ElfTokenPerBlock * GlobalConfig.DividendsForVotersRatio);
+        }
+        
+        public static ulong GetDividendsForAll(ulong minedBlocks)
+        {
+            return minedBlocks * GlobalConfig.ElfTokenPerBlock;
+        }
+    }
+}

--- a/AElf.Contracts.Consensus.DPoS2/Contract_Consensus.cs
+++ b/AElf.Contracts.Consensus.DPoS2/Contract_Consensus.cs
@@ -1,0 +1,294 @@
+using System.Collections.Generic;
+using System.Linq;
+using AElf.Common;
+using AElf.Kernel;
+using AElf.Sdk.CSharp;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace AElf.Contracts.Consensus.DPoS
+{
+    public partial class Contract : CSharpSmartContract<DPoSContractState>//, IConsensusSmartContract
+    {
+        [View]
+        public ValidationResult ValidateConsensus(byte[] consensusInformation)
+        {
+            var dpoSInformation = DPoSInformation.Parser.ParseFrom(consensusInformation);
+            if (TryToGetCurrentRoundInformation(out _))
+            {
+                if (dpoSInformation.MinersList.Any() && !IsMiner(dpoSInformation.Sender))
+                {
+                    return new ValidationResult {Success = false, Message = "Sender is not a miner."};
+                }
+            }
+            else
+            {
+                if (dpoSInformation.MinersList.Any() && !dpoSInformation.MinersList.Contains(dpoSInformation.Sender))
+                {
+                    return new ValidationResult {Success = false, Message = "Sender is not a miner."};
+                }
+            }
+
+            if (TryToGetCurrentRoundInformation(out var currentRound))
+            {
+                if (dpoSInformation.WillUpdateConsensus)
+                {
+                    if (dpoSInformation.Forwarding != null)
+                    {
+                        // Next Round
+                        if (!MinersAreSame(currentRound, dpoSInformation.Forwarding.NextRound))
+                        {
+                            return new ValidationResult {Success = false, Message = "Incorrect miners list."};
+                        }
+
+                        // Maybe it is acceptable to be null.
+//                        if (!OutInValueAreNull(dpoSInformation.Forwarding.NextRound))
+//                        {
+//                            return new ValidationResult {Success = false, Message = "Incorrect Out Value or In Value."};
+//                        }
+
+                        // TODO: Validate time slots (distance == 4000 ms)
+                    }
+
+                    if (dpoSInformation.NewTerm != null)
+                    {
+                        // Next Term
+                        if (!ValidateVictories(dpoSInformation.NewTerm.Miners))
+                        {
+                            return new ValidationResult {Success = false, Message = "Incorrect miners list."};
+                        }
+
+                        if (!OutInValueAreNull(dpoSInformation.NewTerm.FirstRound))
+                        {
+                            return new ValidationResult {Success = false, Message = "Incorrect Out Value or In Value."};
+                        }
+
+                        if (!OutInValueAreNull(dpoSInformation.NewTerm.SecondRound))
+                        {
+                            return new ValidationResult {Success = false, Message = "Incorrect Out Value or In Value."};
+                        }
+
+                        // TODO: Validate time slots (distance == 4000 ms)
+                    }
+                }
+                else
+                {
+                    // Same Round
+                    if (!RoundIdMatched(dpoSInformation.CurrentRound))
+                    {
+                        return new ValidationResult {Success = false, Message = "Round Id not match."};
+                    }
+
+                    if (!NewOutValueFilled(dpoSInformation.CurrentRound))
+                    {
+                        return new ValidationResult {Success = false, Message = "Incorrect new Out Value."};
+                    }
+                }
+            }
+
+            return new ValidationResult {Success = true};
+        }
+
+        public int GetCountingMilliseconds(Timestamp timestamp)
+        {
+            // To initial this chain.
+            if (!TryToGetCurrentRoundInformation(out var roundInformation))
+            {
+                return Config.InitialWaitingMilliseconds;
+            }
+
+            // To terminate current round.
+            if ((AllOutValueFilled(out var minerInformation) || TimeOverflow(timestamp)) &&
+                TryToGetMiningInterval(out var miningInterval))
+            {
+                var extraBlockMiningTime = roundInformation.GetEBPMiningTime(miningInterval);
+                if (roundInformation.GetExtraBlockProducerInformation().PublicKey == Context.RecoverPublicKey().ToHex() &&
+                    extraBlockMiningTime > timestamp.ToDateTime())
+                {
+                    return (int) (extraBlockMiningTime - timestamp.ToDateTime()).TotalMilliseconds;
+                }
+
+                var blockProducerNumber = roundInformation.RealTimeMinersInfo.Count;
+                var roundTime = blockProducerNumber * miningInterval;
+                var passedTime = (timestamp.ToDateTime() - extraBlockMiningTime).TotalMilliseconds % roundTime;
+                if (passedTime > minerInformation.Order * miningInterval)
+                {
+                    return (int) (roundTime - (passedTime - minerInformation.Order * miningInterval));
+                }
+
+                return (int) (minerInformation.Order * miningInterval - passedTime);
+            }
+
+            // To produce a normal block.
+            var expect = (int) (minerInformation.ExpectedMiningTime.ToDateTime() - timestamp.ToDateTime())
+                .TotalMilliseconds;
+            return expect >= 0 ? expect : int.MaxValue;
+        }
+
+        public IMessage GetNewConsensusInformation(byte[] extraInformation)
+        {
+            var extra = DPoSExtraInformation.Parser.ParseFrom(extraInformation);
+
+            // To initial consensus information.
+            if (!TryToGetRoundNumber(out _))
+            {
+                return new DPoSInformation
+                {
+                    Sender = Context.Sender,
+                    WillUpdateConsensus = true,
+                    NewTerm = extra.InitialMiners.ToMiners().GenerateNewTerm(extra.MiningInterval),
+                    MinersList =
+                        {extra.InitialMiners.Select(m => Address.FromPublicKey(ByteArrayHelpers.FromHexString(m)))},
+                };
+            }
+
+            // To terminate current round.
+            if (AllOutValueFilled(out _) || extra.Timestamp != null && TimeOverflow(extra.Timestamp))
+            {
+                return extra.ChangeTerm
+                    ? new DPoSInformation
+                    {
+                        WillUpdateConsensus = true,
+                        Sender = Context.Sender,
+                        NewTerm = GenerateNextTerm(),
+                    }
+                    : new DPoSInformation
+                    {
+                        WillUpdateConsensus = true,
+                        Sender = Context.Sender,
+                        Forwarding = GenerateNewForwarding()
+                    };
+            }
+
+            // To publish Out Value.
+            return new DPoSInformation
+            {
+                CurrentRound = FillOutValue(extra.HashValue)
+            };
+        }
+
+        public TransactionList GenerateConsensusTransactions(ulong refBlockHeight, byte[] refBlockPrefix,
+            byte[] extraInformation)
+        {
+            var extra = DPoSExtraInformation.Parser.ParseFrom(extraInformation);
+
+            // To initial consensus information.
+            if (!TryToGetRoundNumber(out _))
+            {
+                return new TransactionList
+                {
+                    Transactions =
+                    {
+                        GenerateTransaction(refBlockHeight, refBlockPrefix, "InitialTerm",
+                            new List<object> {extra.NewTerm})
+                    }
+                };
+            }
+
+            // To terminate current round.
+            if (AllOutValueFilled(out _) || extra.Timestamp != null && TimeOverflow(extra.Timestamp))
+            {
+                if (extra.ChangeTerm && TryToGetRoundNumber(out var roundNumber) &&
+                    TryToGetTermNumber(out var termNumber))
+                {
+                    return new TransactionList
+                    {
+                        Transactions =
+                        {
+                            GenerateTransaction(refBlockHeight, refBlockPrefix, "NextTerm",
+                                new List<object> {extra.NewTerm}),
+                            GenerateTransaction(refBlockHeight, refBlockPrefix, "SnapshotForMiners",
+                                new List<object> {roundNumber, termNumber}),
+                            GenerateTransaction(refBlockHeight, refBlockPrefix, "SnapshotForTerm",
+                                new List<object> {roundNumber, termNumber}),
+                            GenerateTransaction(refBlockHeight, refBlockPrefix, "SendDividends",
+                                new List<object> {roundNumber, termNumber})
+                        }
+                    };
+                }
+
+                return new TransactionList
+                {
+                    Transactions =
+                    {
+                        GenerateTransaction(refBlockHeight, refBlockPrefix, "BroadcastInValue",
+                            new List<object> {extra.ToBroadcast}),
+                    }
+                };
+            }
+
+            if (extra.InValue != null && extra.ToPackage != null)
+            {
+                return new TransactionList
+                {
+                    Transactions =
+                    {
+                        GenerateTransaction(refBlockHeight, refBlockPrefix, "PackageOutValue",
+                            new List<object> {extra.ToPackage}),
+                        GenerateTransaction(refBlockHeight, refBlockPrefix, "PublishInValue",
+                            new List<object> {extra.InValue}),
+                    }
+                };
+            }
+
+            return new TransactionList();
+        }
+
+        public IMessage GetConsensusCommand(Timestamp timestamp)
+        {
+            // To initial this chain.
+            if (!TryToGetCurrentRoundInformation(out var roundInformation))
+            {
+                return new DPoSCommand
+                {
+                    CountingMilliseconds = Config.InitialWaitingMilliseconds,
+                    Behaviour = DPoSBehaviour.InitialTerm
+                };
+            }
+
+            // To terminate current round.
+            if ((AllOutValueFilled(out var minerInformation) || TimeOverflow(timestamp)) &&
+                TryToGetMiningInterval(out var miningInterval))
+            {
+                var extraBlockMiningTime = roundInformation.GetEBPMiningTime(miningInterval);
+                if (roundInformation.GetExtraBlockProducerInformation().PublicKey == Context.RecoverPublicKey().ToHex() &&
+                    extraBlockMiningTime > timestamp.ToDateTime())
+                {
+                    return new DPoSCommand
+                    {
+                        CountingMilliseconds = (int) (extraBlockMiningTime - timestamp.ToDateTime()).TotalMilliseconds,
+                        Behaviour = DPoSBehaviour.NextRound
+                    };
+                }
+
+                var blockProducerNumber = roundInformation.RealTimeMinersInfo.Count;
+                var roundTime = blockProducerNumber * miningInterval;
+                var passedTime = (timestamp.ToDateTime() - extraBlockMiningTime).TotalMilliseconds % roundTime;
+                if (passedTime > minerInformation.Order * miningInterval)
+                {
+                    return new DPoSCommand
+                    {
+                        CountingMilliseconds =
+                            (int) (roundTime - (passedTime - minerInformation.Order * miningInterval)),
+                        Behaviour = DPoSBehaviour.NextRound
+                    };
+                }
+
+                return new DPoSCommand
+                {
+                    CountingMilliseconds = (int) (minerInformation.Order * miningInterval - passedTime),
+                    Behaviour = DPoSBehaviour.NextRound
+                };
+            }
+
+            // To produce a normal block.
+            var expect = (int) (minerInformation.ExpectedMiningTime.ToDateTime() - timestamp.ToDateTime())
+                .TotalMilliseconds;
+            return new DPoSCommand
+            {
+                CountingMilliseconds = expect >= 0 ? expect : int.MaxValue,
+                Behaviour = DPoSBehaviour.PackageOutValue
+            };
+        }
+    }
+}

--- a/AElf.Contracts.Consensus.DPoS2/Contract_Election_Helper.cs
+++ b/AElf.Contracts.Consensus.DPoS2/Contract_Election_Helper.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using AElf.Common;
+using AElf.Kernel;
+using Google.Protobuf.WellKnownTypes;
+
+namespace AElf.Contracts.Consensus.DPoS
+{
+    public partial class Contract
+    {
+        private ulong CurrentAge => State.AgeField.Value;
+
+        public ActionResult AnnounceElection(string alias = "")
+        {
+            var publicKey = Context.RecoverPublicKey().ToHex();
+            // A voter cannot join the election before all his voting record expired.
+            var tickets = State.TicketsMap[publicKey.ToStringValue()];
+            if (tickets.IsNotEmpty())
+            {
+                foreach (var voteToTransaction in tickets.VoteToTransactions)
+                {
+                    var votingRecord = State.VotingRecordsMap[voteToTransaction];
+                    if (votingRecord.IsNotEmpty())
+                    {
+                        Assert(votingRecord.IsWithdrawn, GlobalConfig.VoterCannotAnnounceElection);
+                    }
+                }
+            }
+
+            Api.LockToken(GlobalConfig.LockTokenForElection);
+            var candidates = State.CandidatesField.Value;
+            if (!candidates.PublicKeys.Contains(publicKey))
+            {
+                candidates.PublicKeys.Add(publicKey);
+            }
+
+            State.CandidatesField.Value = candidates;
+
+            if (alias == "" || alias.Length > GlobalConfig.AliasLimit)
+            {
+                alias = publicKey.Substring(0, GlobalConfig.AliasLimit);
+            }
+
+            var publicKeyOfThisAlias = State.AliasesLookupMap[alias.ToStringValue()];
+            if (publicKeyOfThisAlias.IsNotEmpty() &&
+                publicKey == publicKeyOfThisAlias.Value)
+            {
+                return new ActionResult {Success = true};
+            }
+
+            State.AliasesLookupMap[alias.ToStringValue()] = publicKey.ToStringValue();
+            State.AliasesMap[publicKey.ToStringValue()] = alias.ToStringValue();
+
+            // Add this alias to history information of this candidate.
+            var candidateHistoryInformation = State.HistoryMap[publicKey.ToStringValue()];
+            if (candidateHistoryInformation.IsNotEmpty())
+            {
+                if (!candidateHistoryInformation.Aliases.Contains(alias))
+                {
+                    candidateHistoryInformation.Aliases.Add(alias);
+                    candidateHistoryInformation.CurrentAlias = alias;
+                }
+
+                State.HistoryMap[publicKey.ToStringValue()] = candidateHistoryInformation;
+            }
+            else
+            {
+                State.HistoryMap[publicKey.ToStringValue()] = new CandidateInHistory
+                {
+                    CurrentAlias = alias
+                };
+            }
+
+            return new ActionResult {Success = true};
+        }
+
+        public ActionResult QuitElection()
+        {
+            Api.UnlockToken(Context.Sender, GlobalConfig.LockTokenForElection);
+            var candidates = State.CandidatesField.Value;
+            candidates.PublicKeys.Remove(Context.RecoverPublicKey().ToHex());
+            State.CandidatesField.Value = candidates;
+
+            return new ActionResult {Success = true};
+        }
+
+        public ActionResult Vote(string candidatePublicKey, ulong amount, int lockTime)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            //TODO: Recover after testing.
+//            Api.Assert(lockTime.InRange(90, 1095), GlobalConfig.LockDayIllegal);
+
+            // Cannot vote to non-candidate.
+            var candidates = State.CandidatesField.Value;
+            Assert(candidates.PublicKeys.Contains(candidatePublicKey),
+                GlobalConfig.TargetNotAnnounceElection);
+
+            // A candidate cannot vote to anybody.
+            Assert(!candidates.PublicKeys.Contains(Context.RecoverPublicKey().ToHex()),
+                GlobalConfig.CandidateCannotVote);
+
+            // Transfer the tokens to Consensus Contract address.
+            Api.LockToken(amount);
+
+            var currentTermNumber = State.CurrentTermNumberField.Value;
+            var currentRoundNumber = State.CurrentRoundNumberField.Value;
+
+            // To make up a VotingRecord instance.
+            var blockchainStartTimestamp = State.BlockchainStartTimestamp.Value;
+            var votingRecord = new VotingRecord
+            {
+                Count = amount,
+                From = Context.RecoverPublicKey().ToHex(),
+                To = candidatePublicKey,
+                RoundNumber = currentRoundNumber,
+                TransactionId = Context.TransactionId,
+                VoteAge = CurrentAge,
+                UnlockAge = CurrentAge + (ulong) lockTime,
+                TermNumber = currentTermNumber,
+                VoteTimestamp = blockchainStartTimestamp.ToDateTime().AddDays(CurrentAge).ToTimestamp(),
+                UnlockTimestamp = blockchainStartTimestamp.ToDateTime().AddDays(CurrentAge + (ulong) lockTime)
+                    .ToTimestamp()
+            };
+            votingRecord.LockDaysList.Add(lockTime);
+
+            // Add the transaction id of this voting record to the tickets information of the voter.
+            var tickets = State.TicketsMap[Context.RecoverPublicKey().ToHex().ToStringValue()];
+            if (tickets.IsNotEmpty())
+            {
+                tickets.VoteToTransactions.Add(votingRecord.TransactionId);
+            }
+            else
+            {
+                tickets = new Tickets();
+                tickets.VoteToTransactions.Add(votingRecord.TransactionId);
+            }
+
+            tickets.VotedTickets += votingRecord.Count;
+            tickets.HistoryVotedTickets += votingRecord.Count;
+            State.TicketsMap[Context.RecoverPublicKey().ToHex().ToStringValue()] = tickets;
+
+            // Add the transaction id of this voting record to the tickets information of the candidate.
+            var candidateTickets = State.TicketsMap[candidatePublicKey.ToStringValue()];
+            if (candidateTickets.IsNotEmpty())
+            {
+                candidateTickets.VoteFromTransactions.Add(votingRecord.TransactionId);
+            }
+            else
+            {
+                candidateTickets = new Tickets();
+                candidateTickets.VoteFromTransactions.Add(votingRecord.TransactionId);
+            }
+
+            candidateTickets.ObtainedTickets += votingRecord.Count;
+            candidateTickets.HistoryObtainedTickets += votingRecord.Count;
+            State.TicketsMap[candidatePublicKey.ToStringValue()] = candidateTickets;
+
+            // Update the amount of votes (voting records of whole system).
+            var currentCount = State.VotesCountField.Value;
+            currentCount += 1;
+            State.VotesCountField.Value = currentCount;
+
+            // Update the amount of tickets.
+            var ticketsCount = State.TicketsCountField.Value;
+            ticketsCount += votingRecord.Count;
+            State.TicketsCountField.Value = ticketsCount;
+
+            // Add this voting record to voting records map.
+            State.VotingRecordsMap[votingRecord.TransactionId] = votingRecord;
+
+            // Tell Dividends Contract to add weights for this voting record.
+            State.DividendContract.AddWeights(votingRecord.Weight, currentTermNumber + 1);
+
+            Console.WriteLine($"Weights of vote {votingRecord.TransactionId.ToHex()}: {votingRecord.Weight}");
+            Console.WriteLine($"Vote duration: {stopwatch.ElapsedMilliseconds} ms.");
+            return new ActionResult {Success = true};
+        }
+
+        public ActionResult ReceiveDividends(string transactionId)
+        {
+            var votingRecord = State.VotingRecordsMap[Hash.LoadHex(transactionId)];
+            if (votingRecord.IsNotEmpty() &&
+                votingRecord.From == Context.RecoverPublicKey().ToHex())
+            {
+                State.DividendContract.TransferDividends(votingRecord);
+                return new ActionResult {Success = true};
+            }
+
+            return new ActionResult {Success = false, ErrorMessage = "Voting record not found."};
+        }
+
+        public ActionResult ReceiveDividends()
+        {
+            var tickets = State.TicketsMap[Context.RecoverPublicKey().ToHex().ToStringValue()];
+            if (tickets.IsNotEmpty())
+            {
+                if (!tickets.VoteToTransactions.Any())
+                {
+                    return new ActionResult {Success = false, ErrorMessage = "Voting records not found."};
+                }
+
+                foreach (var transactionId in tickets.VoteToTransactions)
+                {
+                    var votingRecord = State.VotingRecordsMap[transactionId];
+                    if (votingRecord.IsNotEmpty())
+                    {
+                        State.DividendContract.TransferDividends(votingRecord);
+                    }
+                }
+            }
+
+            return new ActionResult {Success = true};
+        }
+
+        public ActionResult Withdraw(string transactionId, bool withoutLimitation)
+        {
+            var votingRecord = State.VotingRecordsMap[Hash.LoadHex(transactionId)];
+            if (votingRecord.IsNotEmpty())
+            {
+                if (votingRecord.IsWithdrawn)
+                {
+                    return new ActionResult
+                        {Success = false, ErrorMessage = "This voting record has already withdrawn."};
+                }
+
+                if ((votingRecord.UnlockAge <= CurrentAge || withoutLimitation) && votingRecord.IsWithdrawn == false)
+                {
+                    State.TokenContract.Transfer(Context.Sender, votingRecord.Count);
+                    State.DividendContract.SubWeights(votingRecord.Weight, State.CurrentTermNumberField.Value);
+
+                    var blockchainStartTimestamp = State.BlockchainStartTimestamp.Value;
+                    votingRecord.WithdrawTimestamp =
+                        blockchainStartTimestamp.ToDateTime().AddDays(CurrentAge).ToTimestamp();
+                    votingRecord.IsWithdrawn = true;
+
+                    State.VotingRecordsMap[Hash.LoadHex(transactionId)] = votingRecord;
+
+                    var ticketsCount = State.TicketsCountField.Value;
+                    ticketsCount -= votingRecord.Count;
+                    State.TicketsCountField.Value = ticketsCount;
+
+                    var ticketsOfVoter = State.TicketsMap[votingRecord.From.ToStringValue()];
+                    if (ticketsOfVoter.IsNotEmpty())
+                    {
+                        ticketsOfVoter.VotedTickets -= votingRecord.Count;
+                        State.TicketsMap[votingRecord.From.ToStringValue()] = ticketsOfVoter;
+                    }
+
+                    var ticketsOfCandidate = State.TicketsMap[votingRecord.To.ToStringValue()];
+                    if (ticketsOfCandidate.IsNotEmpty())
+                    {
+                        ticketsOfCandidate.ObtainedTickets -= votingRecord.Count;
+                        State.TicketsMap[votingRecord.To.ToStringValue()] = ticketsOfCandidate;
+                    }
+                }
+            }
+            else
+            {
+                return new ActionResult {Success = false, ErrorMessage = "Voting record not found."};
+            }
+
+            return new ActionResult {Success = true};
+        }
+
+        public ActionResult Withdraw(bool withoutLimitation = false)
+        {
+            var voterPublicKey = Context.RecoverPublicKey().ToHex();
+            var ticketsCount = State.TicketsCountField.Value;
+            var withdrawnAmount = 0UL;
+            var candidatesVotesDict = new Dictionary<string, ulong>();
+
+            var tickets = State.TicketsMap[voterPublicKey.ToStringValue()];
+            if (tickets.IsNotEmpty())
+            {
+                foreach (var transactionId in tickets.VoteToTransactions)
+                {
+                    var votingRecord = State.VotingRecordsMap[transactionId];
+                    if (votingRecord.IsNotEmpty())
+                    {
+                        if (votingRecord.UnlockAge > CurrentAge && !withoutLimitation)
+                        {
+                            continue;
+                        }
+
+                        State.TokenContract.Transfer(Context.Sender, votingRecord.Count);
+                        State.DividendContract.SubWeights(votingRecord.Weight, State.CurrentTermNumberField.Value);
+//                        Api.SendInline(Api.TokenContractAddress, "Transfer", Api.GetFromAddress(), votingRecord.Count);
+//                        Api.SendInline(Api.DividendsContractAddress, "SubWeights", votingRecord.Weight,
+//                            State.CurrentTermNumberField.Value);
+
+                        var blockchainStartTimestamp = State.BlockchainStartTimestamp.Value;
+                        votingRecord.WithdrawTimestamp =
+                            blockchainStartTimestamp.ToDateTime().AddMinutes(CurrentAge).ToTimestamp();
+                        votingRecord.IsWithdrawn = true;
+
+                        withdrawnAmount += votingRecord.Count;
+                        if (candidatesVotesDict.ContainsKey(votingRecord.To))
+                        {
+                            candidatesVotesDict[votingRecord.To] += votingRecord.Count;
+                        }
+                        else
+                        {
+                            candidatesVotesDict.Add(votingRecord.To, votingRecord.Count);
+                        }
+
+                        State.VotingRecordsMap[votingRecord.TransactionId] = votingRecord;
+                    }
+                }
+
+                ticketsCount -= withdrawnAmount;
+                State.TicketsCountField.Value = ticketsCount;
+
+                tickets.VotedTickets -= withdrawnAmount;
+                State.TicketsMap[voterPublicKey.ToStringValue()] = tickets;
+
+                foreach (var candidateVote in candidatesVotesDict)
+                {
+                    var ticketsOfCandidate = State.TicketsMap[candidateVote.Key.ToStringValue()];
+                    if (ticketsOfCandidate.IsNotEmpty())
+                    {
+                        ticketsOfCandidate.ObtainedTickets -= candidateVote.Value;
+                        State.TicketsMap[candidateVote.Key.ToStringValue()] = ticketsOfCandidate;
+                    }
+                }
+            }
+
+            return new ActionResult {Success = true};
+        }
+    }
+}

--- a/AElf.Contracts.Consensus.DPoS2/Contract_Election_Helper.cs
+++ b/AElf.Contracts.Consensus.DPoS2/Contract_Election_Helper.cs
@@ -29,7 +29,7 @@ namespace AElf.Contracts.Consensus.DPoS
                 }
             }
 
-            Api.LockToken(GlobalConfig.LockTokenForElection);
+            State.TokenContract.Lock(Context.Sender, GlobalConfig.LockTokenForElection);
             var candidates = State.CandidatesField.Value;
             if (!candidates.PublicKeys.Contains(publicKey))
             {
@@ -78,7 +78,7 @@ namespace AElf.Contracts.Consensus.DPoS
 
         public ActionResult QuitElection()
         {
-            Api.UnlockToken(Context.Sender, GlobalConfig.LockTokenForElection);
+            State.TokenContract.Unlock(Context.Sender, GlobalConfig.LockTokenForElection);
             var candidates = State.CandidatesField.Value;
             candidates.PublicKeys.Remove(Context.RecoverPublicKey().ToHex());
             State.CandidatesField.Value = candidates;
@@ -103,7 +103,7 @@ namespace AElf.Contracts.Consensus.DPoS
                 GlobalConfig.CandidateCannotVote);
 
             // Transfer the tokens to Consensus Contract address.
-            Api.LockToken(amount);
+            State.TokenContract.Lock(Context.Sender, amount);
 
             var currentTermNumber = State.CurrentTermNumberField.Value;
             var currentRoundNumber = State.CurrentRoundNumberField.Value;

--- a/AElf.Contracts.Consensus.DPoS2/Contract_Helpers.cs
+++ b/AElf.Contracts.Consensus.DPoS2/Contract_Helpers.cs
@@ -1,0 +1,487 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AElf.Common;
+using AElf.Kernel;
+using AElf.Types.CSharp;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace AElf.Contracts.Consensus.DPoS
+{
+    public partial class Contract
+    {
+//        public Round TryToGetCurrentRoundInformation()
+//        {
+//            var roundNumber = TryToGetRoundNumber();
+//            return roundNumber != 0 ? State.RoundsMap[roundNumber.ToUInt64Value()] : new Round();
+//        }
+//
+//        public ulong TryToGetTermNumber()
+//        {
+//            termNumber = _dataStructures.CurrentTermNumberField.GetValue();
+//        }
+//        public ulong TryToGetRoundNumber()
+//        {
+//            return State.CurrentRoundNumberField.Value;
+//        }
+//        public bool IsMiner(Address address)
+//        {
+//            if (TryToGetTermNumber(out var termNumber))
+//            {
+//                if (TryToGetMiners(termNumber, out var miners))
+//                {
+//                    return miners.Addresses.Contains(address);
+//                }
+//            }
+//
+//            return false;
+//        }
+
+        public bool TryToUpdateRoundNumber(ulong roundNumber)
+        {
+            var oldRoundNumber = State.CurrentRoundNumberField.Value;
+            if (roundNumber != 1 && oldRoundNumber + 1 != roundNumber)
+            {
+                return false;
+            }
+
+            State.CurrentRoundNumberField.Value = roundNumber;
+            return true;
+        }
+
+        public bool TryToUpdateTermNumber(ulong termNumber)
+        {
+            var oldTermNumber = State.CurrentTermNumberField.Value;
+            if (termNumber != 1 && oldTermNumber + 1 != termNumber)
+            {
+                return false;
+            }
+
+            State.CurrentTermNumberField.Value = termNumber;
+            return true;
+        }
+
+        public bool TryToGetRoundNumber(out ulong roundNumber)
+        {
+            roundNumber = State.CurrentRoundNumberField.Value;
+            return roundNumber != 0;
+        }
+
+        public bool TryToGetTermNumber(out ulong termNumber)
+        {
+            termNumber = State.CurrentTermNumberField.Value;
+            return termNumber != 0;
+        }
+
+        public bool TryToGetCurrentRoundInformation(out Round roundInformation)
+        {
+            if (TryToGetRoundNumber(out var roundNumber))
+            {
+                roundInformation = State.RoundsMap[roundNumber.ToUInt64Value()];
+                if (!roundInformation.Equals(new Round()))
+                {
+                    return true;
+                }
+            }
+
+            roundInformation = new Round();
+            return false;
+        }
+
+        public bool TryToGetPreviousRoundInformation(out Round roundInformation)
+        {
+            if (TryToGetRoundNumber(out var roundNumber))
+            {
+                roundInformation = State.RoundsMap[(roundNumber - 1).ToUInt64Value()];
+                if (!roundInformation.Equals(new Round()))
+                {
+                    return true;
+                }
+            }
+
+            roundInformation = new Round();
+            return false;
+        }
+
+        public bool TryToGetRoundInformation(ulong roundNumber, out Round roundInformation)
+        {
+            roundInformation = State.RoundsMap[roundNumber.ToUInt64Value()];
+            return !roundInformation.Equals(new Round());
+        }
+
+        public bool TryToGetMiners(ulong termNumber, out Miners miners)
+        {
+            miners = State.MinersMap[termNumber.ToUInt64Value()];
+            return !miners.Equals(new Miners());
+        }
+
+        public bool TryToGetVictories(out Miners victories)
+        {
+            var candidates = State.CandidatesField.Value;
+            var ticketsMap = new Dictionary<string, ulong>();
+            foreach (var candidatePublicKey in candidates.PublicKeys)
+            {
+                var tickets = State.TicketsMap[candidatePublicKey.ToStringValue()];
+                if (!tickets.Equals(new Tickets()))
+                {
+                    ticketsMap.Add(candidatePublicKey, tickets.ObtainedTickets);
+                }
+            }
+
+            if (ticketsMap.Keys.Count < GlobalConfig.BlockProducerNumber)
+            {
+                victories = null;
+                return false;
+            }
+
+            victories = ticketsMap.OrderByDescending(tm => tm.Value).Take(GlobalConfig.BlockProducerNumber)
+                .Select(tm => tm.Key)
+                .ToList().ToMiners();
+            return true;
+        }
+
+        public bool TryToGetMiningInterval(out int miningInterval)
+        {
+            miningInterval = State.MiningIntervalField.Value;
+            return miningInterval > 0;
+        }
+
+        public bool TryToGetCurrentAge(out ulong blockAge)
+        {
+            blockAge = State.AgeField.Value;
+            return blockAge > 0;
+        }
+
+        public bool TryToGetBlockchainStartTimestamp(out Timestamp timestamp)
+        {
+            timestamp = State.BlockchainStartTimestamp.Value;
+            return timestamp != null;
+        }
+
+        public bool TryToGetMinerHistoryInformation(string publicKey, out CandidateInHistory historyInformation)
+        {
+            historyInformation = State.HistoryMap[publicKey.ToStringValue()];
+            return !historyInformation.Equals(new CandidateInHistory());
+        }
+
+        public bool TryToGetSnapshot(ulong termNumber, out TermSnapshot snapshot)
+        {
+            snapshot = State.SnapshotMap[termNumber.ToUInt64Value()];
+            return !snapshot.Equals(new TermSnapshot());
+        }
+
+        public bool TryToGetTicketsInformation(string publicKey, out Tickets tickets)
+        {
+            tickets = State.TicketsMap[publicKey.ToStringValue()];
+            return !tickets.Equals(new Tickets());
+        }
+
+        public bool TryToGetBackups(List<string> currentMiners, out List<string> backups)
+        {
+            var candidates = State.CandidatesField.Value;
+            backups = candidates.PublicKeys.Except(currentMiners).ToList();
+            return backups.Any();
+        }
+
+        public void SetTermNumber(ulong termNumber)
+        {
+            State.CurrentTermNumberField.Value = termNumber;
+        }
+
+        public void SetRoundNumber(ulong roundNumber)
+        {
+            State.CurrentRoundNumberField.Value = roundNumber;
+        }
+
+        public void SetBlockAge(ulong blockAge)
+        {
+            State.AgeField.Value = blockAge;
+        }
+
+        public void SetBlockchainStartTimestamp(Timestamp timestamp)
+        {
+            State.BlockchainStartTimestamp.Value = timestamp;
+        }
+
+        public void AddOrUpdateMinerHistoryInformation(CandidateInHistory historyInformation)
+        {
+            State.HistoryMap[historyInformation.PublicKey.ToStringValue()] = historyInformation;
+        }
+
+        public bool TryToAddRoundInformation(Round roundInformation)
+        {
+            var ri = State.RoundsMap[roundInformation.RoundNumber.ToUInt64Value()];
+            if (!ri.Equals(new Round()))
+            {
+                return false;
+            }
+
+            State.RoundsMap[roundInformation.RoundNumber.ToUInt64Value()] = roundInformation;
+            return true;
+        }
+
+        public bool TryToUpdateRoundInformation(Round roundInformation)
+        {
+            var ri = State.RoundsMap[roundInformation.RoundNumber.ToUInt64Value()];
+            if (ri.Equals(new Round()))
+            {
+                return false;
+            }
+
+            State.RoundsMap[roundInformation.RoundNumber.ToUInt64Value()] = roundInformation;
+            return true;
+        }
+
+        public void AddOrUpdateTicketsInformation(Tickets tickets)
+        {
+            State.TicketsMap[tickets.PublicKey.ToStringValue()] = tickets;
+        }
+
+        public void SetTermSnapshot(TermSnapshot snapshot)
+        {
+            State.SnapshotMap[snapshot.TermNumber.ToUInt64Value()] = snapshot;
+        }
+
+        public void SetAlias(string publicKey, string alias)
+        {
+            State.AliasesMap[publicKey.ToStringValue()] = alias.ToStringValue();
+            State.AliasesLookupMap[alias.ToStringValue()] = publicKey.ToStringValue();
+        }
+
+        public void SetMiningInterval(int miningInterval)
+        {
+            State.MiningIntervalField.Value = miningInterval;
+        }
+
+        public bool AddTermNumberToFirstRoundNumber(ulong termNumber, ulong firstRoundNumber)
+        {
+            var ri = State.TermToFirstRoundMap[termNumber.ToUInt64Value()];
+            if (!ri.Equals(new UInt64Value()))
+            {
+                return false;
+            }
+
+            State.TermToFirstRoundMap[termNumber.ToUInt64Value()] = firstRoundNumber.ToUInt64Value();
+            return true;
+        }
+
+        public bool SetMiners(Miners miners, bool gonnaReplaceSomeone = false)
+        {
+            // Miners for one specific term should only update once.
+            var m = State.MinersMap[miners.TermNumber.ToUInt64Value()];
+            if (gonnaReplaceSomeone || m.Equals(new Miners()))
+            {
+                State.MinersMap[miners.TermNumber.ToUInt64Value()] = miners;
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool SetSnapshot(TermSnapshot snapshot)
+        {
+            var s = State.SnapshotMap[snapshot.TermNumber.ToUInt64Value()];
+            if (!s.Equals(new TermSnapshot()))
+            {
+                return false;
+            }
+
+            State.SnapshotMap[snapshot.TermNumber.ToUInt64Value()] = snapshot;
+            return true;
+        }
+
+        public bool IsMiner(Address address)
+        {
+            if (TryToGetTermNumber(out var termNumber))
+            {
+                if (TryToGetMiners(termNumber, out var miners))
+                {
+                    return miners.Addresses.Contains(address);
+                }
+            }
+
+            return false;
+        }
+
+        #region Utilities
+
+        private bool MinersAreSame(Round round1, Round round2)
+        {
+            return round1.GetMinersHash() == round2.GetMinersHash();
+        }
+
+        private bool OutInValueAreNull(Round round)
+        {
+            return round.RealTimeMinersInfo.Values.Any(minerInRound =>
+                minerInRound.OutValue != null || minerInRound.InValue != null);
+        }
+
+        private bool ValidateVictories(Miners miners)
+        {
+            if (TryToGetVictories(out var victories))
+            {
+                return victories.GetMinersHash() == miners.GetMinersHash();
+            }
+
+            return false;
+        }
+
+        private bool RoundIdMatched(Round round)
+        {
+            if (TryToGetCurrentRoundInformation(out var currentRoundInStateDB))
+            {
+                return currentRoundInStateDB.RoundId == round.RoundId;
+            }
+
+            return false;
+        }
+
+        private bool NewOutValueFilled(Round round)
+        {
+            if (TryToGetCurrentRoundInformation(out var currentRoundInStateDB))
+            {
+                return currentRoundInStateDB.RealTimeMinersInfo.Values.Count(info => info.OutValue != null) + 1 ==
+                       round.RealTimeMinersInfo.Values.Count(info => info.OutValue != null);
+            }
+
+            return false;
+        }
+
+        private bool AllOutValueFilled(out MinerInRound minerInformation)
+        {
+            minerInformation = null;
+            if (TryToGetCurrentRoundInformation(out var currentRoundInStateDB))
+            {
+                var publicKey = Context.RecoverPublicKey().ToHex();
+                if (currentRoundInStateDB.RealTimeMinersInfo.ContainsKey(publicKey))
+                {
+                    minerInformation = currentRoundInStateDB.RealTimeMinersInfo[publicKey];
+                }
+
+                return currentRoundInStateDB.RealTimeMinersInfo.Values.Count(info => info.OutValue != null) ==
+                       GlobalConfig.BlockProducerNumber;
+            }
+
+            return false;
+        }
+
+        private bool TimeOverflow(Timestamp timestamp)
+        {
+            if (TryToGetCurrentRoundInformation(out var currentRoundInStateDB) &&
+                TryToGetMiningInterval(out var miningInterval))
+            {
+                return currentRoundInStateDB.GetEBPMiningTime(miningInterval).AddMilliseconds(-4000) <
+                       timestamp.ToDateTime();
+            }
+
+            return false;
+        }
+
+        private Round GenerateNextRound()
+        {
+            if (TryToGetCurrentRoundInformation(out var currentRoundInStateDB))
+            {
+                return currentRoundInStateDB.RealTimeMinersInfo.Keys.ToMiners()
+                    .GenerateNextRound(currentRoundInStateDB);
+            }
+
+            return new Round();
+        }
+
+        private Round GenerateNextRound(Round currentRound)
+        {
+            return currentRound.RealTimeMinersInfo.Keys.ToMiners().GenerateNextRound(currentRound);
+        }
+
+        private Forwarding GenerateNewForwarding()
+        {
+            if (TryToGetCurrentAge(out var blockAge) &&
+                TryToGetCurrentRoundInformation(out var currentRound))
+            {
+                if (currentRound.RoundNumber != 1 &&
+                    TryToGetPreviousRoundInformation(out var previousRound))
+                {
+                    return new Forwarding
+                    {
+                        CurrentAge = blockAge,
+                        CurrentRound = currentRound.Supplement(previousRound),
+                        NextRound = GenerateNextRound(currentRound)
+                    };
+                }
+
+                if (currentRound.RoundNumber == 1)
+                {
+                    return new Forwarding
+                    {
+                        CurrentAge = blockAge,
+                        CurrentRound = currentRound.SupplementForFirstRound(),
+                        NextRound = new Round {RoundNumber = 0}
+                    };
+                }
+            }
+
+            return new Forwarding();
+        }
+
+        private Term GenerateNextTerm()
+        {
+            if (TryToGetTermNumber(out var termNumber) &&
+                TryToGetRoundNumber(out var roundNumber) &&
+                TryToGetVictories(out var victories) &&
+                TryToGetMiningInterval(out var miningInterval))
+            {
+                return victories.GenerateNewTerm(miningInterval, roundNumber, termNumber);
+            }
+
+            return new Term();
+        }
+
+        private Round FillOutValue(Hash outValue)
+        {
+            if (TryToGetCurrentRoundInformation(out var currentRoundInStateDB))
+            {
+                var publicKey = Context.RecoverPublicKey().ToHex();
+                if (currentRoundInStateDB.RealTimeMinersInfo.ContainsKey(publicKey))
+                {
+                    currentRoundInStateDB.RealTimeMinersInfo[publicKey].OutValue = outValue;
+                }
+
+                return currentRoundInStateDB;
+            }
+
+            return new Round();
+        }
+
+        private DateTime GetExtraBlockMiningTime(int miningInterval)
+        {
+            if (TryToGetCurrentRoundInformation(out var currentRoundInStateDB))
+            {
+                return currentRoundInStateDB.GetEBPMiningTime(miningInterval);
+            }
+
+            return DateTime.MaxValue;
+        }
+
+        private Transaction GenerateTransaction(ulong refBlockHeight, byte[] refBlockPrefix, string methodName,
+            List<object> parameters)
+        {
+            refBlockHeight = refBlockHeight > 4 ? refBlockHeight - 4 : 0;
+
+            var tx = new Transaction
+            {
+                From = Context.Sender,
+                To = Context.Self,
+                RefBlockNumber = refBlockHeight,
+                RefBlockPrefix = ByteString.CopyFrom(refBlockPrefix),
+                MethodName = methodName,
+                Type = TransactionType.DposTransaction,
+                Params = ByteString.CopyFrom(ParamsPacker.Pack(parameters.ToArray()))
+            };
+
+            return tx;
+        }
+
+        #endregion
+    }
+}

--- a/AElf.Contracts.Consensus.DPoS2/Contract_Process.cs
+++ b/AElf.Contracts.Consensus.DPoS2/Contract_Process.cs
@@ -1,0 +1,52 @@
+using AElf.Kernel;
+using Google.Protobuf.WellKnownTypes;
+
+namespace AElf.Contracts.Consensus.DPoS
+{
+    public partial class Contract
+    {
+        public void InitialTerm(Term term)
+        {
+            Assert(term.FirstRound.RoundNumber == 1, "It seems that the term number of initial term is incorrect.");
+            Assert(term.SecondRound.RoundNumber == 2,
+                "It seems that the term number of initial term is incorrect.");
+            Process_InitialTerm(term);
+        }
+
+        public ActionResult NextTerm(Term term)
+        {
+            return Process_NextTerm(term);
+        }
+
+        public ActionResult SnapshotForMiners(ulong previousTermNumber, ulong lastRoundNumber)
+        {
+            return Process_SnapshotForMiners(previousTermNumber, lastRoundNumber);
+        }
+
+        public ActionResult SnapshotForTerm(ulong snapshotTermNumber, ulong lastRoundNumber)
+        {
+            return Process_SnapshotForTerm(snapshotTermNumber, lastRoundNumber);
+        }
+
+        public ActionResult SendDividends(ulong dividendsTermNumber, ulong lastRoundNumber)
+        {
+            return Process_SendDividends(dividendsTermNumber, lastRoundNumber);
+        }
+
+        public void NextRound(Forwarding forwarding)
+        {
+            Process_NextRound(forwarding);
+        }
+
+        public void PackageOutValue(ToPackage toPackage)
+        {
+            Process_PackageOutValue(toPackage);
+        }
+
+
+        public void BroadcastInValue(ToBroadcast toBroadcast)
+        {
+            Process_BroadcastInValue(toBroadcast);
+        }
+    }
+}

--- a/AElf.Contracts.Consensus.DPoS2/Contract_Process_Helper.cs
+++ b/AElf.Contracts.Consensus.DPoS2/Contract_Process_Helper.cs
@@ -1,0 +1,693 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using AElf.Common;
+using AElf.Configuration.Config.Chain;
+using AElf.Kernel;
+using Google.Protobuf.WellKnownTypes;
+
+namespace AElf.Contracts.Consensus.DPoS
+{
+    public partial class Contract
+    {
+        private int LogLevel { get; set; } = 0;
+
+        public void Process_InitialTerm(Term firstTerm)
+        {
+            InitialBlockchain(firstTerm);
+
+            InitialMainchainToken();
+
+            SetAliases(firstTerm);
+
+            var senderPublicKey = Context.RecoverPublicKey().ToHex();
+
+            // Update ProducedBlocks for sender.
+            if (firstTerm.FirstRound.RealTimeMinersInfo.ContainsKey(senderPublicKey))
+            {
+                firstTerm.FirstRound.RealTimeMinersInfo[senderPublicKey].ProducedBlocks += 1;
+            }
+            else
+            {
+                // The sender isn't a initial miner, need to update its history information.
+                if (TryToGetMinerHistoryInformation(senderPublicKey, out var historyInformation))
+                {
+                    historyInformation.ProducedBlocks += 1;
+                }
+                else
+                {
+                    // Create a new history information.
+                    historyInformation = new CandidateInHistory
+                    {
+                        PublicKey = senderPublicKey,
+                        ProducedBlocks = 1,
+                        CurrentAlias = senderPublicKey.Substring(0, GlobalConfig.AliasLimit)
+                    };
+                }
+
+                AddOrUpdateMinerHistoryInformation(historyInformation);
+            }
+
+            firstTerm.FirstRound.BlockchainAge = 1;
+            firstTerm.SecondRound.BlockchainAge = 1;
+            TryToAddRoundInformation(firstTerm.FirstRound);
+            TryToAddRoundInformation(firstTerm.SecondRound);
+        }
+
+        public ActionResult Process_NextTerm(Term term)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            // Count missed time slot of current round.
+            CountMissedTimeSlots();
+
+            Assert(TryToGetTermNumber(out var termNumber), "Term number not found.");
+            State.DividendContract.KeepWeights(termNumber);
+
+            // Update current term number and current round number.
+            Assert(TryToUpdateTermNumber(term.TermNumber), "Failed to update term number.");
+            Assert(TryToUpdateRoundNumber(term.FirstRound.RoundNumber), "Failed to update round number.");
+
+            // Reset some fields of first two rounds of next term.
+            foreach (var minerInRound in term.FirstRound.RealTimeMinersInfo.Values)
+            {
+                minerInRound.MissedTimeSlots = 0;
+                minerInRound.ProducedBlocks = 0;
+            }
+
+            foreach (var minerInRound in term.SecondRound.RealTimeMinersInfo.Values)
+            {
+                minerInRound.MissedTimeSlots = 0;
+                minerInRound.ProducedBlocks = 0;
+            }
+
+            var senderPublicKey = Context.RecoverPublicKey().ToHex();
+
+            // Update produced block number of this node.
+            if (term.FirstRound.RealTimeMinersInfo.ContainsKey(senderPublicKey))
+            {
+                term.FirstRound.RealTimeMinersInfo[senderPublicKey].ProducedBlocks += 1;
+            }
+            else
+            {
+                if (TryToGetMinerHistoryInformation(senderPublicKey, out var historyInformation))
+                {
+                    historyInformation.ProducedBlocks += 1;
+                }
+                else
+                {
+                    historyInformation = new CandidateInHistory
+                    {
+                        PublicKey = senderPublicKey,
+                        ProducedBlocks = 1,
+                        CurrentAlias = senderPublicKey.Substring(0, GlobalConfig.AliasLimit)
+                    };
+                }
+
+                AddOrUpdateMinerHistoryInformation(historyInformation);
+            }
+
+            // Update miners list.
+            SetMiners(term.Miners);
+
+            // Update term number lookup. (Using term number to get first round number of related term.)
+            AddTermNumberToFirstRoundNumber(term.TermNumber, term.FirstRound.RoundNumber);
+
+            Assert(TryToGetCurrentAge(out var blockAge), "Block age not found.");
+            // Update blockchain age of next two rounds.
+            term.FirstRound.BlockchainAge = blockAge;
+            term.SecondRound.BlockchainAge = blockAge;
+
+            // Update rounds information of next two rounds.
+            TryToAddRoundInformation(term.FirstRound);
+            TryToAddRoundInformation(term.SecondRound);
+
+            Console.WriteLine($"Term changing duration: {stopwatch.ElapsedMilliseconds} ms.");
+
+            return new ActionResult {Success = true};
+        }
+
+        /// <summary>
+        /// Take a snapshot of specific term.
+        /// Basically this snapshot is used for getting ranks of candidates of specific term.
+        /// </summary>
+        /// <param name="snapshotTermNumber"></param>
+        /// <param name="lastRoundNumber"></param>
+        /// <returns></returns>
+        public ActionResult Process_SnapshotForTerm(ulong snapshotTermNumber, ulong lastRoundNumber)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            if (TryToGetSnapshot(snapshotTermNumber, out _))
+            {
+                return new ActionResult
+                {
+                    Success = false,
+                    ErrorMessage = $"Snapshot of term {snapshotTermNumber} already taken."
+                };
+            }
+
+            if (!TryToGetRoundInformation(lastRoundNumber, out var roundInformation))
+            {
+                return new ActionResult
+                {
+                    Success = false,
+                    ErrorMessage = $"Failed to get information of round {lastRoundNumber}."
+                };
+            }
+
+            // To calculate the number of mined blocks.
+            var minedBlocks = roundInformation.RealTimeMinersInfo.Values.Aggregate<MinerInRound, ulong>(0,
+                (current, minerInRound) => current + minerInRound.ProducedBlocks);
+
+            // Snapshot for the number of votes of new victories.
+            var candidateInTerms = new List<CandidateInTerm>();
+            if (TryToGetVictories(out var victories))
+            {
+                foreach (var candidatePublicKey in victories.PublicKeys)
+                {
+                    if (TryToGetTicketsInformation(candidatePublicKey, out var candidateTickets))
+                    {
+                        candidateInTerms.Add(new CandidateInTerm
+                        {
+                            PublicKey = candidatePublicKey,
+                            Votes = candidateTickets.ObtainedTickets
+                        });
+                    }
+                    else
+                    {
+                        AddOrUpdateTicketsInformation(new Tickets {PublicKey = candidatePublicKey});
+                        candidateInTerms.Add(new CandidateInTerm
+                        {
+                            PublicKey = candidatePublicKey,
+                            Votes = 0
+                        });
+                    }
+                }
+            }
+
+            Assert(TryToGetRoundNumber(out var roundNumber), "Round number not found.");
+            // Set snapshot of related term.
+            SetSnapshot(new TermSnapshot
+            {
+                TermNumber = snapshotTermNumber,
+                EndRoundNumber = roundNumber,
+                TotalBlocks = minedBlocks,
+                CandidatesSnapshot = {candidateInTerms}
+            });
+
+            Console.WriteLine($"Snapshot of term {snapshotTermNumber} taken.");
+
+            Console.WriteLine($"Term snapshot duration: {stopwatch.ElapsedMilliseconds} ms.");
+
+            return new ActionResult {Success = true};
+        }
+
+        public ActionResult Process_SnapshotForMiners(ulong previousTermNumber, ulong lastRoundNumber)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            Assert(TryToGetRoundInformation(lastRoundNumber, out var roundInformation),
+                "Round information not found.");
+
+            foreach (var candidate in roundInformation.RealTimeMinersInfo)
+            {
+                CandidateInHistory candidateInHistory;
+                if (TryToGetMinerHistoryInformation(candidate.Key, out var historyInformation))
+                {
+                    var terms = new List<ulong>(historyInformation.Terms.ToList());
+
+                    if (terms.Contains(previousTermNumber))
+                    {
+                        return new ActionResult
+                            {Success = false, ErrorMessage = "Snapshot for miners in previous term already taken."};
+                    }
+
+                    terms.Add(previousTermNumber);
+
+                    var continualAppointmentCount = historyInformation.ContinualAppointmentCount;
+                    if (TryToGetMiners(previousTermNumber, out var minersOfLastTerm) &&
+                        minersOfLastTerm.PublicKeys.Contains(candidate.Key))
+                    {
+                        continualAppointmentCount++;
+                    }
+                    else
+                    {
+                        continualAppointmentCount = 0;
+                    }
+
+                    candidateInHistory = new CandidateInHistory
+                    {
+                        PublicKey = candidate.Key,
+                        MissedTimeSlots = historyInformation.MissedTimeSlots + candidate.Value.MissedTimeSlots,
+                        ProducedBlocks = historyInformation.ProducedBlocks + candidate.Value.ProducedBlocks,
+                        ContinualAppointmentCount = continualAppointmentCount,
+                        ReappointmentCount = historyInformation.ReappointmentCount + 1,
+                        CurrentAlias = historyInformation.CurrentAlias,
+                        Terms = {terms}
+                    };
+                }
+                else
+                {
+                    candidateInHistory = new CandidateInHistory
+                    {
+                        PublicKey = candidate.Key,
+                        MissedTimeSlots = candidate.Value.MissedTimeSlots,
+                        ProducedBlocks = candidate.Value.ProducedBlocks,
+                        ContinualAppointmentCount = 0,
+                        ReappointmentCount = 0,
+                        Terms = {previousTermNumber}
+                    };
+                }
+
+                AddOrUpdateMinerHistoryInformation(candidateInHistory);
+            }
+
+            Console.WriteLine($"Miners snapshot duration: {stopwatch.ElapsedMilliseconds} ms.");
+
+            return new ActionResult {Success = true};
+        }
+
+        public ActionResult Process_SendDividends(ulong dividendsTermNumber, ulong lastRoundNumber)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            Assert(TryToGetRoundInformation(lastRoundNumber, out var roundInformation),
+                "Round information not found.");
+
+            // Set dividends of related term to Dividends Contract.
+            var minedBlocks = roundInformation.RealTimeMinersInfo.Values.Aggregate<MinerInRound, ulong>(0,
+                (current, minerInRound) => current + minerInRound.ProducedBlocks);
+            State.DividendContract.AddDividends(dividendsTermNumber, Config.GetDividendsForVoters(minedBlocks));
+
+            ulong totalVotes = 0;
+            ulong totalReappointment = 0;
+            var continualAppointmentDict = new Dictionary<string, ulong>();
+            foreach (var minerInRound in roundInformation.RealTimeMinersInfo)
+            {
+                if (TryToGetTicketsInformation(minerInRound.Key, out var candidateTickets))
+                {
+                    totalVotes += candidateTickets.ObtainedTickets;
+                }
+
+                if (TryToGetMinerHistoryInformation(minerInRound.Key, out var candidateInHistory))
+                {
+                    totalReappointment += candidateInHistory.ContinualAppointmentCount;
+
+                    continualAppointmentDict.Add(minerInRound.Key, candidateInHistory.ContinualAppointmentCount);
+                }
+
+                // Transfer dividends for actual miners. (The miners list based on last round of current term.)
+                Api.SendDividends(
+                    Address.FromPublicKey(ByteArrayHelpers.FromHexString(minerInRound.Key)),
+                    Config.GetDividendsForEveryMiner(minedBlocks) +
+                    (totalVotes == 0
+                        ? 0
+                        : Config.GetDividendsForTicketsCount(minedBlocks) * candidateTickets.ObtainedTickets /
+                          totalVotes) +
+                    (totalReappointment == 0
+                        ? 0
+                        : Config.GetDividendsForReappointment(minedBlocks) *
+                          continualAppointmentDict[minerInRound.Key] /
+                          totalReappointment));
+            }
+
+            if (TryToGetBackups(roundInformation.RealTimeMinersInfo.Keys.ToList(), out var backups))
+            {
+                foreach (var backup in backups)
+                {
+                    var backupCount = (ulong) backups.Count;
+                    Api.SendDividends(
+                        Address.FromPublicKey(ByteArrayHelpers.FromHexString(backup)),
+                        backupCount == 0 ? 0 : Config.GetDividendsForBackupNodes(minedBlocks) / backupCount);
+                }
+            }
+
+            Console.WriteLine($"Send dividends duration: {stopwatch.ElapsedMilliseconds} ms.");
+
+            return new ActionResult {Success = true};
+        }
+
+        public void Process_NextRound(Forwarding forwarding)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            Assert(
+                forwarding.NextRound.RoundNumber == 0 || TryToGetRoundNumber(out var roundNumber) &&
+                roundNumber < forwarding.NextRound.RoundNumber, "Incorrect round number for next round.");
+
+            var senderPublicKey = Context.RecoverPublicKey().ToHex();
+
+            if (IsMainchain() && TryToGetCurrentRoundInformation(out var currentRoundInformation) &&
+                forwarding.NextRound.GetMinersHash() != currentRoundInformation.GetMinersHash() &&
+                forwarding.NextRound.RealTimeMinersInfo.Keys.Count == GlobalConfig.BlockProducerNumber &&
+                TryToGetTermNumber(out var termNumber))
+            {
+                var miners = forwarding.NextRound.RealTimeMinersInfo.Keys.ToMiners();
+                miners.TermNumber = termNumber;
+                SetMiners(miners, true);
+            }
+
+            // Update the age of this blockchain
+            SetBlockAge(forwarding.CurrentAge);
+
+            // Check whether round id matched.
+            var forwardingCurrentRound = forwarding.CurrentRound;
+            TryToGetCurrentRoundInformation(out var currentRound);
+            Assert(forwardingCurrentRound.RoundId == currentRound.RoundId, GlobalConfig.RoundIdNotMatched);
+
+            var completeCurrentRoundInfo = Process_SupplyCurrentRoundInfo(currentRound, forwardingCurrentRound);
+
+            Assert(TryToGetCurrentAge(out var blockAge), "Block age not found.");
+
+            Assert(TryToGetRoundNumber(out var currentRoundNumber), "Round number not found.");
+
+            // When the node is in Round 1, gonna just update the data of Round 2 instead of re-generate orders.
+            if (forwarding.NextRound.RoundNumber == 0)
+            {
+                if (TryToGetRoundInformation(currentRound.RoundNumber + 1, out var nextRound))
+                {
+                    foreach (var minerInRound in completeCurrentRoundInfo.RealTimeMinersInfo)
+                    {
+                        nextRound.RealTimeMinersInfo[minerInRound.Key].MissedTimeSlots =
+                            minerInRound.Value.MissedTimeSlots;
+                        nextRound.RealTimeMinersInfo[minerInRound.Key].ProducedBlocks =
+                            minerInRound.Value.ProducedBlocks;
+                    }
+
+                    nextRound.BlockchainAge = blockAge;
+                    if (forwarding.NextRound.RealTimeMinersInfo.ContainsKey(senderPublicKey))
+                    {
+                        nextRound.RealTimeMinersInfo[senderPublicKey].ProducedBlocks += 1;
+                    }
+                    else
+                    {
+                        if (TryToGetMinerHistoryInformation(senderPublicKey, out var historyInformation))
+                        {
+                            historyInformation.ProducedBlocks += 1;
+                        }
+                        else
+                        {
+                            historyInformation = new CandidateInHistory
+                            {
+                                PublicKey = senderPublicKey,
+                                ProducedBlocks = 1,
+                                CurrentAlias = senderPublicKey.Substring(0, GlobalConfig.AliasLimit)
+                            };
+                        }
+
+                        AddOrUpdateMinerHistoryInformation(historyInformation);
+                    }
+
+                    TryToAddRoundInformation(nextRound);
+                    SetRoundNumber(2);
+                }
+            }
+            else
+            {
+                // Update missed time slots and produced blocks for each miner.
+                foreach (var minerInRound in completeCurrentRoundInfo.RealTimeMinersInfo)
+                {
+                    if (forwarding.NextRound.RealTimeMinersInfo.ContainsKey(minerInRound.Key))
+                    {
+                        forwarding.NextRound.RealTimeMinersInfo[minerInRound.Key].MissedTimeSlots =
+                            minerInRound.Value.MissedTimeSlots;
+                        forwarding.NextRound.RealTimeMinersInfo[minerInRound.Key].ProducedBlocks =
+                            minerInRound.Value.ProducedBlocks;
+                    }
+                    else
+                    {
+                        if (TryToGetMinerHistoryInformation(senderPublicKey, out var historyInformation))
+                        {
+                            historyInformation.ProducedBlocks += minerInRound.Value.ProducedBlocks;
+                            historyInformation.MissedTimeSlots += minerInRound.Value.MissedTimeSlots;
+                        }
+                        else
+                        {
+                            historyInformation = new CandidateInHistory
+                            {
+                                PublicKey = senderPublicKey,
+                                ProducedBlocks = minerInRound.Value.ProducedBlocks,
+                                MissedTimeSlots = minerInRound.Value.MissedTimeSlots,
+                                CurrentAlias = senderPublicKey.Substring(0, GlobalConfig.AliasLimit)
+                            };
+                        }
+
+                        AddOrUpdateMinerHistoryInformation(historyInformation);
+                    }
+                }
+
+                forwarding.NextRound.BlockchainAge = blockAge;
+                if (forwarding.NextRound.RealTimeMinersInfo.ContainsKey(senderPublicKey))
+                {
+                    forwarding.NextRound.RealTimeMinersInfo[senderPublicKey].ProducedBlocks += 1;
+                }
+                else
+                {
+                    if (TryToGetMinerHistoryInformation(senderPublicKey, out var historyInformation))
+                    {
+                        historyInformation.ProducedBlocks += 1;
+                    }
+                    else
+                    {
+                        historyInformation = new CandidateInHistory
+                        {
+                            PublicKey = senderPublicKey,
+                            ProducedBlocks = 1,
+                            CurrentAlias = senderPublicKey.Substring(0, GlobalConfig.AliasLimit)
+                        };
+                    }
+
+                    AddOrUpdateMinerHistoryInformation(historyInformation);
+                }
+
+                if (currentRoundNumber > GlobalConfig.ForkDetectionRoundNumber)
+                {
+                    foreach (var minerInRound in forwarding.NextRound.RealTimeMinersInfo)
+                    {
+                        minerInRound.Value.LatestMissedTimeSlots = 0;
+                    }
+
+                    var rounds = new List<Round>();
+                    for (var i = currentRoundNumber - GlobalConfig.ForkDetectionRoundNumber + 1;
+                        i <= currentRoundNumber;
+                        i++)
+                    {
+                        Assert(TryToGetRoundInformation(i, out var round),
+                            GlobalConfig.RoundNumberNotFound);
+                        rounds.Add(round);
+                    }
+
+                    foreach (var round in rounds)
+                    {
+                        foreach (var minerInRound in round.RealTimeMinersInfo)
+                        {
+                            if (minerInRound.Value.IsMissed &&
+                                forwarding.NextRound.RealTimeMinersInfo.ContainsKey(minerInRound.Key))
+                            {
+                                forwarding.NextRound.RealTimeMinersInfo[minerInRound.Key].LatestMissedTimeSlots +=
+                                    1;
+                            }
+
+                            if (!minerInRound.Value.IsMissed &&
+                                forwarding.NextRound.RealTimeMinersInfo.ContainsKey(minerInRound.Key))
+                            {
+                                forwarding.NextRound.RealTimeMinersInfo[minerInRound.Key].LatestMissedTimeSlots = 0;
+                            }
+                        }
+                    }
+                }
+
+                TryToAddRoundInformation(forwarding.NextRound);
+                TryToUpdateRoundNumber(forwarding.NextRound.RoundNumber);
+            }
+
+            Console.WriteLine($"Round changing duration: {stopwatch.ElapsedMilliseconds} ms.");
+        }
+
+        public void Process_PackageOutValue(ToPackage toPackage)
+        {
+            Assert(TryToGetCurrentRoundInformation(out var currentRound) &&
+                       toPackage.RoundId == currentRound.RoundId, GlobalConfig.RoundIdNotMatched);
+
+            Assert(TryToGetCurrentRoundInformation(out var roundInformation),
+                "Round information not found.");
+
+            if (roundInformation.RoundNumber != 1)
+            {
+                roundInformation.RealTimeMinersInfo[Context.RecoverPublicKey().ToHex()].Signature = toPackage.Signature;
+            }
+
+            roundInformation.RealTimeMinersInfo[Context.RecoverPublicKey().ToHex()].OutValue = toPackage.OutValue;
+
+            roundInformation.RealTimeMinersInfo[Context.RecoverPublicKey().ToHex()].ProducedBlocks += 1;
+
+            TryToAddRoundInformation(roundInformation);
+        }
+
+        public void Process_BroadcastInValue(ToBroadcast toBroadcast)
+        {
+            if (TryToGetCurrentRoundInformation(out var currentRound) &&
+                toBroadcast.RoundId != currentRound.RoundId)
+            {
+                return;
+            }
+
+            Assert(TryToGetCurrentRoundInformation(out var roundInformation),
+                "Round information not found.");
+            Assert(roundInformation.RealTimeMinersInfo[Context.RecoverPublicKey().ToHex()].OutValue != null,
+                GlobalConfig.OutValueIsNull);
+            Assert(roundInformation.RealTimeMinersInfo[Context.RecoverPublicKey().ToHex()].Signature != null,
+                GlobalConfig.SignatureIsNull);
+            Assert(
+                roundInformation.RealTimeMinersInfo[Context.RecoverPublicKey().ToHex()].OutValue ==
+                Hash.FromMessage(toBroadcast.InValue),
+                GlobalConfig.InValueNotMatchToOutValue);
+
+            roundInformation.RealTimeMinersInfo[Context.RecoverPublicKey().ToHex()].InValue = toBroadcast.InValue;
+
+            TryToAddRoundInformation(roundInformation);
+        }
+
+        #region Vital Steps
+
+        private void InitialBlockchain(Term firstTerm)
+        {
+            SetTermNumber(1);
+            SetRoundNumber(1);
+            SetBlockAge(1);
+            AddTermNumberToFirstRoundNumber(1, 1);
+            SetBlockchainStartTimestamp(firstTerm.Timestamp);
+            SetMiners(firstTerm.Miners);
+            SetMiningInterval(firstTerm.MiningInterval);
+        }
+
+        private void InitialMainchainToken()
+        {
+            State.TokenContract.Initialize("ELF", "AElf Token", GlobalConfig.TotalSupply, 2);
+        }
+
+        private void SetAliases(Term term)
+        {
+            var index = 0;
+            if (IsMainchain())
+            {
+                foreach (var publicKey in term.Miners.PublicKeys)
+                {
+                    if (index >= Config.Aliases.Count)
+                        return;
+
+                    var alias = Config.Aliases[index];
+                    SetAlias(publicKey, alias);
+                    AddOrUpdateMinerHistoryInformation(new CandidateInHistory
+                        {PublicKey = publicKey, CurrentAlias = alias});
+                    index++;
+                }
+            }
+            else
+            {
+                foreach (var publicKey in term.Miners.PublicKeys)
+                {
+                    var alias = publicKey.Substring(0, GlobalConfig.AliasLimit);
+                    SetAlias(publicKey, alias);
+                    ConsoleWriteLine(nameof(SetAliases), $"Set alias {alias} to {publicKey}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Can only supply signature, out value, in value if one missed his time slot.
+        /// </summary>
+        /// <param name="currentRound"></param>
+        /// <param name="forwardingCurrentRound"></param>
+        private Round Process_SupplyCurrentRoundInfo(Round currentRound, Round forwardingCurrentRound)
+        {
+            foreach (var suppliedMiner in forwardingCurrentRound.RealTimeMinersInfo)
+            {
+                if (suppliedMiner.Value.MissedTimeSlots >
+                    currentRound.RealTimeMinersInfo[suppliedMiner.Key].MissedTimeSlots
+                    && currentRound.RealTimeMinersInfo[suppliedMiner.Key].OutValue == null)
+                {
+                    currentRound.RealTimeMinersInfo[suppliedMiner.Key].OutValue = suppliedMiner.Value.OutValue;
+                    currentRound.RealTimeMinersInfo[suppliedMiner.Key].InValue = suppliedMiner.Value.InValue;
+                    currentRound.RealTimeMinersInfo[suppliedMiner.Key].Signature = suppliedMiner.Value.Signature;
+
+                    currentRound.RealTimeMinersInfo[suppliedMiner.Key].MissedTimeSlots += 1;
+                    currentRound.RealTimeMinersInfo[suppliedMiner.Key].IsMissed = true;
+                }
+            }
+
+            TryToUpdateRoundInformation(currentRound);
+
+            return currentRound;
+        }
+
+        #endregion
+
+        public IEnumerable<string> GetVictories()
+        {
+            if (TryToGetVictories(out var victories))
+            {
+                return victories.PublicKeys;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Normally this process contained in NextRound method.
+        /// </summary>
+        private void CountMissedTimeSlots()
+        {
+            if (TryToGetCurrentRoundInformation(out var currentRound))
+            {
+                foreach (var minerInRound in currentRound.RealTimeMinersInfo)
+                {
+                    if (minerInRound.Value.OutValue == null)
+                    {
+                        minerInRound.Value.MissedTimeSlots += 1;
+                    }
+                }
+
+                TryToUpdateRoundInformation(currentRound);
+            }
+        }
+
+        /// <summary>
+        /// Debug level:
+        /// 6 = Off
+        /// 5 = Fatal
+        /// 4 = Error
+        /// 3 = Warn
+        /// 2 = Info
+        /// 1 = Debug
+        /// 0 = Trace
+        /// </summary>
+        /// <param name="prefix"></param>
+        /// <param name="log"></param>
+        /// <param name="ex"></param>
+        private void ConsoleWriteLine(string prefix, string log, Exception ex = null)
+        {
+            if (LogLevel == 6)
+                return;
+
+            Console.WriteLine(
+                $"[{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff} - Consensus]{prefix} - {log}.");
+            if (ex != null)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+        private bool IsMainchain()
+        {
+            return ChainConfig.Instance.ChainId == GlobalConfig.DefaultChainId;
+        }
+    }
+}

--- a/AElf.Contracts.Consensus.DPoS2/DPoSContractState.cs
+++ b/AElf.Contracts.Consensus.DPoS2/DPoSContractState.cs
@@ -1,0 +1,177 @@
+using System;
+using AElf.Common;
+using AElf.Kernel;
+using AElf.Sdk.CSharp.State;
+using Google.Protobuf.WellKnownTypes;
+
+namespace AElf.Contracts.Consensus.DPoS
+{
+    public class RoundsMapState : MappedState<UInt64Value, Round>
+    {
+    }
+
+    public class MinersMapState : MappedState<UInt64Value, Miners>
+    {
+    }
+
+    public class TicketsMapState : MappedState<StringValue, Tickets>
+    {
+    }
+
+    public class SnapshotMapState : MappedState<UInt64Value, TermSnapshot>
+    {
+    }
+
+    public class AliasesMapState : MappedState<StringValue, StringValue>
+    {
+    }
+
+    public class AliasesLookupMapState : MappedState<StringValue, StringValue>
+    {
+    }
+
+    public class HistoryMapState : MappedState<StringValue, CandidateInHistory>
+    {
+    }
+
+    public class AgeToRoundNumberMapState : MappedState<UInt64Value, UInt64Value>
+    {
+    }
+
+    public class VotingRecordsMapState : MappedState<Hash, VotingRecord>
+    {
+    }
+
+    public class TermToFirstRoundMapState : MappedState<UInt64Value, UInt64Value>
+    {
+    }
+
+    public class DividendContractReferenceState : ContractReferenceState
+    {
+        public Action<ulong> KeepWeights { get; set; }
+        public Action<ulong,ulong> SubWeights { get; set; }
+        public Action<ulong, ulong> AddWeights { get; set; }
+        public Action<ulong, ulong> AddDividends { get; set; }
+        public Action<VotingRecord> TransferDividends { get; set; }
+    }
+
+    public class TokenContractReferenceState : ContractReferenceState
+    {
+        public Action<string, string, ulong, uint> Initialize { get; set; }
+        public Action<Address, ulong> Transfer { get; set; }
+    }
+
+    public class DPoSContractState : ContractState
+    {
+        public DividendContractReferenceState DividendContract { get; set; }
+        public TokenContractReferenceState TokenContract { get; set; }
+
+        /// <summary>
+        /// Current round number.
+        /// </summary>
+        public UInt64State CurrentRoundNumberField { get; set; }
+
+        /// <summary>
+        /// Current term number.
+        /// </summary>
+        public UInt64State CurrentTermNumberField { get; set; }
+
+        /// <summary>
+        /// Record the start round of each term.
+        /// In Map: term number -> round number
+        /// </summary>
+        public SingletonState<TermNumberLookUp> TermNumberLookupField { get; set; }
+
+        /// <summary>
+        /// Timestamp for genesis of this blockchain.
+        /// </summary>
+        public SingletonState<Timestamp> BlockchainStartTimestamp { get; set; }
+
+        /// <summary>
+        /// The nodes declared join the election for Miners.
+        /// </summary>
+        public SingletonState<Candidates> CandidatesField { get; set; }
+
+        /// <summary>
+        /// Days since we started this blockchain.
+        /// </summary>
+        public UInt64State AgeField { get; set; }
+
+        /// <summary>
+        /// DPoS information of each round.
+        /// round number -> round information
+        /// </summary>
+        public RoundsMapState RoundsMap { get; set; }
+
+        /// <summary>
+        /// DPoS mining interval.
+        /// </summary>
+        public Int32State MiningIntervalField { get; set; }
+
+        /// <summary>
+        /// Miners of each term.
+        /// term number -> miners
+        /// </summary>
+        public MinersMapState MinersMap;
+
+        /// <summary>
+        /// Tickets of each address (public key).
+        /// public key hex value -> tickets information
+        /// </summary>
+        public TicketsMapState TicketsMap;
+
+        /// <summary>
+        /// Snapshots of all terms.
+        /// term number -> snapshot
+        /// </summary>
+        public SnapshotMapState SnapshotMap;
+
+        /// <summary>
+        /// Aliases of candidates.
+        /// candidate public key hex value -> alias
+        /// </summary>
+        public AliasesMapState AliasesMap;
+
+        /// <summary>
+        /// Aliases of candidates.
+        /// alias -> candidate public key hex value
+        /// </summary>
+        public AliasesLookupMapState AliasesLookupMap;
+
+        /// <summary>
+        /// Histories of all candidates
+        /// candidate public key hex value -> history information
+        /// </summary>
+        public HistoryMapState HistoryMap;
+
+        /// <summary>
+        /// blockchain age -> first round number.
+        /// </summary>
+        public AgeToRoundNumberMapState AgeToRoundNumberMap;
+
+        /// <summary>
+        /// Keep tracking of the count of votes.
+        /// </summary>
+        public UInt64State VotesCountField;
+
+        /// <summary>
+        /// Keep tracking of the count of tickets.
+        /// </summary>
+        public UInt64State TicketsCountField;
+
+        /// <summary>
+        /// Whether 2/3 of miners mined in current term.
+        /// </summary>
+        public BoolState TwoThirdsMinersMinedCurrentTermField;
+
+        /// <summary>
+        /// Transaction Id -> Voting Record.
+        /// </summary>
+        public VotingRecordsMapState VotingRecordsMap;
+
+        /// <summary>
+        /// Term Number -> First Round Number of this term.
+        /// </summary>
+        public TermToFirstRoundMapState TermToFirstRoundMap;
+    }
+}

--- a/AElf.Contracts.Consensus.DPoS2/DPoSContractState.cs
+++ b/AElf.Contracts.Consensus.DPoS2/DPoSContractState.cs
@@ -49,7 +49,7 @@ namespace AElf.Contracts.Consensus.DPoS
     public class DividendContractReferenceState : ContractReferenceState
     {
         public Action<ulong> KeepWeights { get; set; }
-        public Action<ulong,ulong> SubWeights { get; set; }
+        public Action<ulong, ulong> SubWeights { get; set; }
         public Action<ulong, ulong> AddWeights { get; set; }
         public Action<ulong, ulong> AddDividends { get; set; }
         public Action<VotingRecord> TransferDividends { get; set; }
@@ -60,6 +60,8 @@ namespace AElf.Contracts.Consensus.DPoS
     {
         public Action<string, string, ulong, uint> Initialize { get; set; }
         public Action<Address, ulong> Transfer { get; set; }
+        public Action<Address, ulong> Lock { get; set; }
+        public Action<Address, ulong> Unlock { get; set; }
     }
 
     public class DPoSContractState : ContractState

--- a/AElf.Contracts.Consensus.DPoS2/DPoSContractState.cs
+++ b/AElf.Contracts.Consensus.DPoS2/DPoSContractState.cs
@@ -53,6 +53,7 @@ namespace AElf.Contracts.Consensus.DPoS
         public Action<ulong, ulong> AddWeights { get; set; }
         public Action<ulong, ulong> AddDividends { get; set; }
         public Action<VotingRecord> TransferDividends { get; set; }
+        public Action<Address, ulong> SendDividends { get; set; }
     }
 
     public class TokenContractReferenceState : ContractReferenceState

--- a/AElf.Contracts.Consensus.DPoS2/IMessageExtensions.cs
+++ b/AElf.Contracts.Consensus.DPoS2/IMessageExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Google.Protobuf;
+
+namespace AElf.Contracts.Consensus.DPoS
+{
+    public static class IMessageExtensions
+    {
+        private static readonly Dictionary<Type, object> _empties = new Dictionary<Type, object>();
+
+        private static object GetEmpty(IMessage message)
+        {
+            var type = message.GetType();
+            if (_empties.TryGetValue(type, out var empty))
+            {
+                return empty;
+            }
+
+            empty = Activator.CreateInstance(type);
+            _empties.Add(type, empty);
+            return empty;
+        }
+
+        public static bool IsEmpty(this IMessage message)
+        {
+            return message.Equals(GetEmpty(message));
+        }
+
+        public static bool IsNotEmpty(this IMessage message)
+        {
+            return !message.IsEmpty();
+        }
+    }
+}

--- a/AElf.Sdk.CSharp2/Context.cs
+++ b/AElf.Sdk.CSharp2/Context.cs
@@ -3,6 +3,7 @@ using AElf.Common;
 using AElf.Kernel;
 using System.Linq;
 using System.Reflection;
+using AElf.Cryptography;
 using AElf.Sdk.CSharp.ReadOnly;
 using AElf.Sdk.CSharp.State;
 using AElf.SmartContract;
@@ -21,8 +22,19 @@ namespace AElf.Sdk.CSharp
             TransactionContext.Trace.Logs.Add(logEvent.GetLogEvent(Self));
         }
 
+        public Hash TransactionId => TransactionContext.Transaction.GetHash();
         public Address Sender => TransactionContext.Transaction.From.ToReadOnly();
         public Address Self => SmartContractContext.ContractAddress.ToReadOnly();
+
+        /// <summary>
+        /// Recovers the first public key signing this transaction.
+        /// </summary>
+        /// <returns>Public key byte array</returns>
+        public byte[] RecoverPublicKey()
+        {
+            return RecoverPublicKey(TransactionContext.Transaction.Sigs.First().ToByteArray(),
+                TransactionContext.Transaction.GetHash().DumpByteArray());
+        }
 
         public void SendInline(Address address, string methodName, params object[] args)
         {
@@ -33,6 +45,12 @@ namespace AElf.Sdk.CSharp
                 MethodName = methodName,
                 Params = ByteString.CopyFrom(ParamsPacker.Pack(args))
             });
+        }
+
+        private static byte[] RecoverPublicKey(byte[] signature, byte[] hash)
+        {
+            var cabBeRecovered = CryptoHelpers.RecoverPublicKey(signature, hash, out var publicKey);
+            return !cabBeRecovered ? null : publicKey;
         }
     }
 }

--- a/AElf.Sdk.CSharp2/IContext.cs
+++ b/AElf.Sdk.CSharp2/IContext.cs
@@ -7,8 +7,10 @@ namespace AElf.Sdk.CSharp
     public interface IContext
     {
         void FireEvent(Event logEvent);
+        Hash TransactionId { get; }
         Address Sender { get; }
         Address Self { get; }
+        byte[] RecoverPublicKey();
 //        Hash ChainId { get; }
 //        Address ContractZeroAddress { get; }
 //

--- a/AElf.sln
+++ b/AElf.sln
@@ -187,6 +187,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AElf.Contracts.Consensus.DP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AElf.Consensus.DPoS", "AElf.Consensus.DPoS\AElf.Consensus.DPoS.csproj", "{74FA5F2B-E691-483B-B19E-8DF288C1C04B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AElf.Contracts.Consensus.DPoS2", "AElf.Contracts.Consensus.DPoS2\AElf.Contracts.Consensus.DPoS2.csproj", "{AC8BC006-BEE1-4DBE-878B-696FC56EE1AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -529,6 +531,10 @@ Global
 		{74FA5F2B-E691-483B-B19E-8DF288C1C04B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74FA5F2B-E691-483B-B19E-8DF288C1C04B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74FA5F2B-E691-483B-B19E-8DF288C1C04B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC8BC006-BEE1-4DBE-878B-696FC56EE1AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC8BC006-BEE1-4DBE-878B-696FC56EE1AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC8BC006-BEE1-4DBE-878B-696FC56EE1AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC8BC006-BEE1-4DBE-878B-696FC56EE1AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -583,5 +589,6 @@ Global
 		{48D25035-5446-47BD-8006-3D3590094310} = {FD93DE86-68EC-49B8-B732-DC3AFC9ADCC1}
 		{31FC0E10-B49E-4FEE-BFDE-76A39C6064FB} = {D9406971-FFD3-4D0D-9D2F-DFF10D38A0DC}
 		{621FA51E-593C-4E2E-86A4-CF173F108839} = {D3950CC9-808F-4ED8-946A-79A992F3F8EF}
+		{AC8BC006-BEE1-4DBE-878B-696FC56EE1AD} = {D9406971-FFD3-4D0D-9D2F-DFF10D38A0DC}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Inline calls has been standardized to use ContractReferenceState, the sender being the current contract.
LockToken, UnlockToken and SendDividends to be removed from API and implemented in Token contract and Dividends contract.