### PR TITLE
Fixed block download order.

### DIFF
--- a/AElf.Kernel.Tests/Blockchain/Application/FullBlockchainServiceTests.cs
+++ b/AElf.Kernel.Tests/Blockchain/Application/FullBlockchainServiceTests.cs
@@ -113,7 +113,7 @@ namespace AElf.Kernel.Blockchain.Application
         [Fact]
         public async Task Get_GetReservedBlockHashes_ReturnNull()
         {
-            var result = await _fullBlockchainService.GetReservedBlockHashes(_chainId, Hash.FromString("not exist"), 1);
+            var result = await _fullBlockchainService.GetReversedBlockHashes(_chainId, Hash.FromString("not exist"), 1);
             result.ShouldBeNull();
         }
 
@@ -132,7 +132,7 @@ namespace AElf.Kernel.Blockchain.Application
         {
             var (chain, blockList) = await CreateNewChainWithBlock(_chainId, 3);
 
-            var result = await _fullBlockchainService.GetReservedBlockHashes(chain.Id, blockList[2].GetHash(), 2);
+            var result = await _fullBlockchainService.GetReversedBlockHashes(chain.Id, blockList[2].GetHash(), 2);
             result.Count.ShouldBe(2);
             result[0].ShouldBe(blockList[1].GetHash());
             result[1].ShouldBe(blockList[0].GetHash());

--- a/AElf.OS.Core/Jobs/ForkDownloadJob.cs
+++ b/AElf.OS.Core/Jobs/ForkDownloadJob.cs
@@ -42,6 +42,8 @@ namespace AElf.OS.Jobs
                         $"Failed to finish download of {args.BlockHashes.Count} blocks from {args.Peer}: chain not found.");
                 }
 
+                args.BlockHashes.Reverse();
+
                 foreach (var hash in args.BlockHashes.Select(Hash.LoadByteArray))
                 {
                     // Check that some other job didn't get this before.

--- a/AElf.OS.Network.Grpc/GrpcServerService.cs
+++ b/AElf.OS.Network.Grpc/GrpcServerService.cs
@@ -203,9 +203,9 @@ namespace AElf.OS.Network.Grpc
             
             try
             {
-                Logger.LogDebug($"Peer {context.Peer} requested block ids: from {request.FirstBlockId}, count : {request.Count}.");
+                Logger.LogDebug($"Peer {context.Peer} requested block ids: from {Hash.LoadByteArray(request.FirstBlockId.ToByteArray())}, count : {request.Count}.");
                 
-                var headers = await _blockChainService.GetReservedBlockHashes(ChainId, 
+                var headers = await _blockChainService.GetReversedBlockHashes(ChainId, 
                     Hash.LoadByteArray(request.FirstBlockId.ToByteArray()), request.Count);
                 
                 BlockIdList list = new BlockIdList();


### PR DESCRIPTION
Fixes the following:
- download order when syncing multiple blocks.
- protect against requesting blocks below the genesis.

fixes #1011 