### PR TITLE
resolve #1256

### DIFF
--- a/AElf.Kernel.SmartContract.Tests/SerializedCallGraphTest.cs
+++ b/AElf.Kernel.SmartContract.Tests/SerializedCallGraphTest.cs
@@ -1,0 +1,109 @@
+using System;
+using Shouldly;
+using Xunit;
+
+namespace AElf.Kernel.SmartContract
+{
+    public class SerializedCallGraphTest
+    {
+        [Fact]
+        public void IEquatable_SerializedCallGraph_Equals_Other_True()
+        {
+            IEquatable<SerializedCallGraph> serializedCallGraph = new SerializedCallGraph
+            {
+                Edges =
+                {
+                    new GraphEdge {Source = "Source1", Target = "Target1"},
+                    new GraphEdge {Source = "Source2", Target = "Target2"},
+                    new GraphEdge {Source = "Source3", Target = "Target3"}
+                },
+                Vertices = {"Vertices"}
+            };
+            
+            var otherSerializedCallGraph = new SerializedCallGraph
+            {
+                Edges =
+                {
+                    new GraphEdge {Source = "Source1", Target = "Target1"},
+                    new GraphEdge {Source = "Source2", Target = "Target2"},
+                    new GraphEdge {Source = "Source3", Target = "Target3"}
+                },
+                Vertices = {"Vertices"}
+            };
+
+            serializedCallGraph.Equals(otherSerializedCallGraph).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IEquatable_SerializedCallGraph_Equals_Other_False()
+        {
+            IEquatable<SerializedCallGraph> serializedCallGraph = new SerializedCallGraph
+            {
+                Edges =
+                {
+                    new GraphEdge {Source = "Source1", Target = "Target1"},
+                    new GraphEdge {Source = "Source2", Target = "Target2"},
+                    new GraphEdge {Source = "Source3", Target = "Target3"}
+                },
+                Vertices = {"Vertices"}
+            };
+            
+            serializedCallGraph.Equals(new SerializedCallGraph()).ShouldBeFalse();
+            
+            var otherSerializedCallGraph1 = new SerializedCallGraph
+            {
+                Edges =
+                {
+                    new GraphEdge {Source = "Source1", Target = "Target1"},
+                    new GraphEdge {Source = "Source2", Target = "Target2"},
+                    new GraphEdge {Source = "Source3", Target = "Target4"}
+                },
+                Vertices = {"Vertices"}
+            };
+
+            serializedCallGraph.Equals(otherSerializedCallGraph1).ShouldBeFalse();
+            
+            var otherSerializedCallGraph2 = new SerializedCallGraph
+            {
+                Edges =
+                {
+                    new GraphEdge {Source = "Source1", Target = "Target1"},
+                    new GraphEdge {Source = "Source2", Target = "Target2"},
+                    new GraphEdge {Source = "Source3", Target = "Target3"}
+                },
+                Vertices = {"OtherVertices"}
+            };
+
+            serializedCallGraph.Equals(otherSerializedCallGraph2).ShouldBeFalse();
+            
+            var otherSerializedCallGraph3 = new SerializedCallGraph
+            {
+                Edges =
+                {
+                    new GraphEdge {Source = "Source1", Target = "Target1"},
+                    new GraphEdge {Source = "Source2", Target = "Target2"},
+                    new GraphEdge {Source = "Source3", Target = "Target4"}
+                },
+                Vertices = {"OtherVertices"}
+            };
+
+            serializedCallGraph.Equals(otherSerializedCallGraph3).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IEquatable_SerializedCallGraph_Equals_Null_False()
+        {
+            IEquatable<SerializedCallGraph> serializedCallGraph = new SerializedCallGraph
+            {
+                Edges =
+                {
+                    new GraphEdge {Source = "Source1", Target = "Target1"},
+                    new GraphEdge {Source = "Source2", Target = "Target2"},
+                    new GraphEdge {Source = "Source3", Target = "Target3"}
+                },
+                Vertices = {"Vertices"}
+            };
+            serializedCallGraph.Equals(null).ShouldBeFalse();
+        }
+    }
+}

--- a/AElf.Kernel.Types/SmartContract/SerializedCallGraph.cs
+++ b/AElf.Kernel.Types/SmartContract/SerializedCallGraph.cs
@@ -9,6 +9,8 @@ namespace AElf.Kernel.SmartContract
     {
         bool IEquatable<SerializedCallGraph>.Equals(SerializedCallGraph other)
         {
+            if (other == null) return false;
+            
             var edges = new RepeatedField<GraphEdge>();
             edges.AddRange(Edges.OrderBy(e => e.Source).ThenBy(e => e.Target));
             var otherEdges = new RepeatedField<GraphEdge>();


### PR DESCRIPTION
fix NullReferenceException of IEquatable<SerializedCallGraph>.Equals 

add cases to cover IEquatable<SerializedCallGraph>.Equals