### PR TITLE
Fix benchmark startup

### DIFF
--- a/bench/AElf.Benchmark/Program.cs
+++ b/bench/AElf.Benchmark/Program.cs
@@ -14,12 +14,7 @@ namespace AElf.Benchmark
             }))
             {
                 application.Initialize();
-#if DEBUG
                 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());          
-#else
-                BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-
-#endif
             }
         }
     }


### PR DESCRIPTION
BenchmarkSwitcher had some problems with the default config, and I'll troubleshooting that later.