### PR TITLE
Send announcement to multiple peers at the same time.

### DIFF
--- a/src/AElf.OS.Core/Network/Application/NetworkService.cs
+++ b/src/AElf.OS.Core/Network/Application/NetworkService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using AElf.Kernel;
 using AElf.OS.Network.Infrastructure;
@@ -63,7 +64,7 @@ namespace AElf.OS.Network.Application
                     Logger.LogDebug($"Block announced: {announce}");
                     await peer.AnnounceAsync(announce);
                     
-                    successfulBcasts++;
+                    Interlocked.Increment(ref successfulBcasts);
                 }
                 catch (NetworkException e)
                 {

--- a/src/AElf.OS/Handlers/BlockAcceptedEventHandler.cs
+++ b/src/AElf.OS/Handlers/BlockAcceptedEventHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using AElf.Kernel.Blockchain.Events;
 using AElf.OS.Network.Application;
@@ -12,9 +13,10 @@ namespace AElf.OS.Handlers
         {
             public INetworkService NetworkService { get; set; }
 
-            public async Task HandleEventAsync(BlockAcceptedEvent eventData)
+            public Task HandleEventAsync(BlockAcceptedEvent eventData)
             {
-                await NetworkService.BroadcastAnnounceAsync(eventData.BlockHeader);
+                NetworkService.BroadcastAnnounceAsync(eventData.BlockHeader);
+                return Task.CompletedTask;
             }
         }
     }


### PR DESCRIPTION
- Task.WhenAll for sending.
- broadcast announce is now fire and forget.