### PR TITLE
Fix transaction expire issue

### DIFF
--- a/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
+++ b/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
@@ -88,14 +88,12 @@ namespace AElf.Kernel.TransactionPool.Infrastructure
         private static void AddToCollection(ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>> collection,
             TransactionReceipt receipt)
         {
-            if (!collection.TryGetValue(receipt.Transaction.RefBlockNumber, out var receipts))
-            {
+            if (collection.TryGetValue(receipt.Transaction.RefBlockNumber, out var receipts))
+                if (receipts.ContainsKey(receipt.TransactionId)) return;
+            else
                 receipts = new ConcurrentDictionary<Hash, TransactionReceipt>();
-                collection.TryAdd(receipt.Transaction.RefBlockNumber, receipts);
-            }
-
-            if (receipts.ContainsKey(receipt.TransactionId)) return;
-            receipts.TryAdd(receipt.TransactionId, receipt);
+            
+            collection.TryAdd(receipt.Transaction.RefBlockNumber, receipts);
         }
 
         private static void CheckPrefixForOne(TransactionReceipt receipt, ByteString prefix, long bestChainHeight)

--- a/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
+++ b/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
@@ -94,6 +94,7 @@ namespace AElf.Kernel.TransactionPool.Infrastructure
                 collection.TryAdd(receipt.Transaction.RefBlockNumber, receipts);
             }
 
+            if (receipts.Keys.Contains(receipt.TransactionId)) return;
             receipts.Add(receipt.TransactionId, receipt);
         }
 

--- a/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
+++ b/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
@@ -94,7 +94,7 @@ namespace AElf.Kernel.TransactionPool.Infrastructure
                 collection.TryAdd(receipt.Transaction.RefBlockNumber, receipts);
             }
 
-            if (receipts.Keys.Contains(receipt.TransactionId)) return;
+            if (receipts.ContainsKey(receipt.TransactionId)) return;
             receipts.Add(receipt.TransactionId, receipt);
         }
 

--- a/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
+++ b/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
@@ -94,7 +94,6 @@ namespace AElf.Kernel.TransactionPool.Infrastructure
                 collection.TryAdd(receipt.Transaction.RefBlockNumber, receipts);
             }
 
-            if (receipts.ContainsKey(receipt.TransactionId)) return;
             receipts.TryAdd(receipt.TransactionId, receipt);
         }
 

--- a/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
+++ b/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
@@ -28,14 +28,14 @@ namespace AElf.Kernel.TransactionPool.Infrastructure
 
         private ConcurrentDictionary<Hash, TransactionReceipt> _validated = new ConcurrentDictionary<Hash, TransactionReceipt>();
 
-        private ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>> _invalidatedByBlock =
-            new ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>>();
+        private ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>> _invalidatedByBlock =
+            new ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>>();
 
-        private ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>> _expiredByExpiryBlock =
-            new ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>>();
+        private ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>> _expiredByExpiryBlock =
+            new ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>>();
 
-        private ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>> _futureByBlock =
-            new ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>>();
+        private ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>> _futureByBlock =
+            new ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>>();
 
         private long _bestChainHeight = Constants.GenesisBlockHeight - 1;
         private Hash _bestChainHash = Hash.Empty;
@@ -85,17 +85,17 @@ namespace AElf.Kernel.TransactionPool.Infrastructure
 
         #region Private Static Methods
 
-        private static void AddToCollection(ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>> collection,
+        private static void AddToCollection(ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>> collection,
             TransactionReceipt receipt)
         {
             if (!collection.TryGetValue(receipt.Transaction.RefBlockNumber, out var receipts))
             {
-                receipts = new Dictionary<Hash, TransactionReceipt>();
+                receipts = new ConcurrentDictionary<Hash, TransactionReceipt>();
                 collection.TryAdd(receipt.Transaction.RefBlockNumber, receipts);
             }
 
             if (receipts.ContainsKey(receipt.TransactionId)) return;
-            receipts.Add(receipt.TransactionId, receipt);
+            receipts.TryAdd(receipt.TransactionId, receipt);
         }
 
         private static void CheckPrefixForOne(TransactionReceipt receipt, ByteString prefix, long bestChainHeight)
@@ -150,9 +150,9 @@ namespace AElf.Kernel.TransactionPool.Infrastructure
 
         private void ResetCurrentCollections()
         {
-            _expiredByExpiryBlock = new ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>>();
-            _invalidatedByBlock = new ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>>();
-            _futureByBlock = new ConcurrentDictionary<long, Dictionary<Hash, TransactionReceipt>>();
+            _expiredByExpiryBlock = new ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>>();
+            _invalidatedByBlock = new ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>>();
+            _futureByBlock = new ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>>();
             _validated = new ConcurrentDictionary<Hash, TransactionReceipt>();
         }
 

--- a/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
+++ b/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs
@@ -88,12 +88,14 @@ namespace AElf.Kernel.TransactionPool.Infrastructure
         private static void AddToCollection(ConcurrentDictionary<long, ConcurrentDictionary<Hash, TransactionReceipt>> collection,
             TransactionReceipt receipt)
         {
-            if (collection.TryGetValue(receipt.Transaction.RefBlockNumber, out var receipts))
-                if (receipts.ContainsKey(receipt.TransactionId)) return;
-            else
+            if (!collection.TryGetValue(receipt.Transaction.RefBlockNumber, out var receipts))
+            {
                 receipts = new ConcurrentDictionary<Hash, TransactionReceipt>();
-            
-            collection.TryAdd(receipt.Transaction.RefBlockNumber, receipts);
+                collection.TryAdd(receipt.Transaction.RefBlockNumber, receipts);
+            }
+
+            if (receipts.ContainsKey(receipt.TransactionId)) return;
+            receipts.TryAdd(receipt.TransactionId, receipt);
         }
 
         private static void CheckPrefixForOne(TransactionReceipt receipt, ByteString prefix, long bestChainHeight)

--- a/src/AElf.Kernel.Types/KernelTypesConsts.cs
+++ b/src/AElf.Kernel.Types/KernelTypesConsts.cs
@@ -5,7 +5,7 @@ namespace AElf.Kernel
     public static class KernelConstants
     {
 //        public const long GenesisBlockHeight = 1;
-        public const long ReferenceBlockValidPeriod = 64;
+        public const long ReferenceBlockValidPeriod = 64 * 8;
         public const int ProtocolVersion = 1;
         public const int DefaultRunnerCategory = 0;
         public const int CodeCoverageRunnerCategory = 30;


### PR DESCRIPTION
## Description
User sent transactions if expired or expired very quickly, maybe filtered twice in TxHub and got exception.

User ClientError:
response.StatusCode
    should be
HttpStatusCode.OK
    but was
HttpStatusCode.InternalServerError))

Node Error:
2019-05-17 06:21:36,760 [25] ERROR Volo.Abp.AspNetCore.Mvc.ExceptionHandling.AbpExceptionFilter - ---------- RemoteServiceErrorInfo ----------
2019-05-17 06:21:36,769 [25] ERROR Volo.Abp.AspNetCore.Mvc.ExceptionHandling.AbpExceptionFilter - {
  "code": null,
  "message": "An internal error occurred during your request!",
  "details": null,
  "validationErrors": null
}
2019-05-17 06:21:36,771 [25] ERROR Volo.Abp.AspNetCore.Mvc.ExceptionHandling.AbpExceptionFilter - Object reference not set to an instance of an object.
System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at AElf.Kernel.TransactionPool.Infrastructure.TxHub.AddToCollection(ConcurrentDictionary`2 collection, TransactionReceipt receipt) in /home/aelf/github/AElf/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs:line 97
   at AElf.Kernel.TransactionPool.Infrastructure.TxHub.AddToRespectiveCurrentCollection(TransactionReceipt receipt) in /home/aelf/github/AElf/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs:line 163
   at AElf.Kernel.TransactionPool.Infrastructure.TxHub.HandleTransactionsReceivedAsync(TransactionsReceivedEvent eventData) in /home/aelf/github/AElf/src/AElf.Kernel.TransactionPool/Infrastructure/TxHub.cs:line 229
   at AElf.Kernel.TransactionPool.Application.TxPoolInterestedEventsHandler.HandleEventAsync(TransactionsReceivedEvent eventData) in /home/aelf/github/AElf/src/AElf.Kernel.TransactionPool/Application/TxPoolInterestedEventsHandler.cs:line 27
   at Volo.Abp.EventBus.EventBusBase.TriggerHandlerAsync(IEventHandlerFactory asyncHandlerFactory, Type eventType, Object eventData, List`1 exceptions)
   at Volo.Abp.EventBus.Local.LocalEventBus.PublishAsync(Type eventType, Object eventData)
   at AElf.WebApp.Application.Chain.BlockChainAppService.PublishTransactionsAsync(String[] rawTransactions) in /home/aelf/github/AElf/src/AElf.WebApp.Application.Chain/BlockChainAppService.cs:line 599
   at AElf.WebApp.Application.Chain.BlockChainAppService.BroadcastTransactions(BroadcastTransactionsInput input) in /home/aelf/github/AElf/src/AElf.WebApp.Application.Chain/BlockChainAppService.cs:line 215
   at lambda_method(Closure , Object )
   at Microsoft.Extensions.Internal.ObjectMethodExecutorAwaitable.Awaiter.GetResult()
   at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.AwaitableObjectResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
   at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
   at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
   at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
   at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextExceptionFilterAsync()