### PR TITLE
Whitelist System.Text for both release and debug builds

### DIFF
--- a/src/AElf.Runtime.CSharp.Core/Policies/DefaultPolicy.cs
+++ b/src/AElf.Runtime.CSharp.Core/Policies/DefaultPolicy.cs
@@ -127,10 +127,11 @@ namespace AElf.Runtime.CSharp.Policies
                     .Type(nameof(RuntimeHelpers), Permission.Denied, member => member
                         .Member(nameof(RuntimeHelpers.InitializeArray), Permission.Allowed)))
                 
-                #if DEBUG
-                // Allow printing logs
+                // TODO: Allow System.Text only for system contracts
+                // Used for logging and other string operations, conversions
                 .Namespace("System.Text", Permission.Allowed)
                 
+                #if DEBUG
                 // Allow coverlet injected codes
                 .Namespace("System.IO.MemoryMappedFiles", Permission.Allowed)
                 .Namespace("System.Threading", Permission.Allowed)


### PR DESCRIPTION
Currently cannot run node due to AEDPoS contract deployment failure when Launcher is built in Release mode.

This was not noticed in unit tests because the code that whitelist System.Text was only there when built in Debug mode and unit tests are run in Debug mode.