### PR TITLE
Improve location of specified extensions

### DIFF
--- a/contract/AElf.Contracts.Genesis/BasicContractZero.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZero.cs
@@ -211,7 +211,7 @@ namespace AElf.Contracts.Genesis
 
         public static Address BuildContractAddress(int chainId, ulong serialNumber)
         {
-            return BuildContractAddress(chainId.ComputeHash(), serialNumber);
+            return BuildContractAddress(chainId.ToHash(), serialNumber);
         }
     }
 }

--- a/src/AElf.Kernel.Core/Blockchain/Infrastructure/IStaticChainInformationProvider.cs
+++ b/src/AElf.Kernel.Core/Blockchain/Infrastructure/IStaticChainInformationProvider.cs
@@ -42,7 +42,7 @@ namespace AElf.Kernel.Blockchain.Infrastructure
 
         public static Address BuildContractAddress(int chainId, ulong serialNumber)
         {
-            return BuildContractAddress(chainId.ComputeHash(), serialNumber);
+            return BuildContractAddress(chainId.ToHash(), serialNumber);
         }
     }
 }

--- a/src/AElf.Types/Extensions/ByteExtensions.cs
+++ b/src/AElf.Types/Extensions/ByteExtensions.cs
@@ -43,33 +43,7 @@ namespace AElf
 
             return new string(c);
         }
-
-        public static string ToHex(this ByteString bytes, bool withPrefix = false)
-        {
-            int offset = withPrefix ? 2 : 0;
-            int length = bytes.Length * 2 + offset;
-            char[] c = new char[length];
-
-            byte b;
-
-            if (withPrefix)
-            {
-                c[0] = '0';
-                c[1] = 'x';
-            }
-
-            for (int bx = 0, cx = offset; bx < bytes.Length; ++bx, ++cx)
-            {
-                b = ((byte) (bytes[bx] >> 4));
-                c[cx] = (char) (b > 9 ? b + 0x37 + 0x20 : b + 0x30);
-
-                b = ((byte) (bytes[bx] & 0x0F));
-                c[++cx] = (char) (b > 9 ? b + 0x37 + 0x20 : b + 0x30);
-            }
-
-            return new string(c);
-        }
-
+        
         /// <summary>
         /// Calculates the hash for a byte array.
         /// </summary>

--- a/src/AElf.Types/Extensions/ByteStringExtensions.cs
+++ b/src/AElf.Types/Extensions/ByteStringExtensions.cs
@@ -1,0 +1,33 @@
+using  Google.Protobuf;
+
+namespace AElf
+{
+    public static class ByteStringExtensions
+    {
+        public static string ToHex(this ByteString bytes, bool withPrefix = false)
+        {
+            int offset = withPrefix ? 2 : 0;
+            int length = bytes.Length * 2 + offset;
+            char[] c = new char[length];
+
+            byte b;
+
+            if (withPrefix)
+            {
+                c[0] = '0';
+                c[1] = 'x';
+            }
+
+            for (int bx = 0, cx = offset; bx < bytes.Length; ++bx, ++cx)
+            {
+                b = ((byte) (bytes[bx] >> 4));
+                c[cx] = (char) (b > 9 ? b + 0x37 + 0x20 : b + 0x30);
+
+                b = ((byte) (bytes[bx] & 0x0F));
+                c[++cx] = (char) (b > 9 ? b + 0x37 + 0x20 : b + 0x30);
+            }
+
+            return new string(c);
+        }
+    }
+}

--- a/src/AElf.Types/Extensions/HashExtensions.cs
+++ b/src/AElf.Types/Extensions/HashExtensions.cs
@@ -5,7 +5,7 @@ namespace AElf
 {
     public static class HashExtensions
     {
-        public static Hash ComputeHash(this int obj)
+        public static Hash ToHash(this int obj)
         {
             return Hash.FromRawBytes(BitConverter.GetBytes(obj));
         }

--- a/src/AElf.Types/Extensions/HexExtensions.cs
+++ b/src/AElf.Types/Extensions/HexExtensions.cs
@@ -4,9 +4,6 @@ namespace AElf
 {
     public static class HexExtensions
     {
-        public static byte[] DumpByteArray(this int n)
-        {
-            return BitConverter.GetBytes(n);
-        }
+
     }
 }

--- a/src/AElf.Types/Extensions/NumbericExtensions.cs
+++ b/src/AElf.Types/Extensions/NumbericExtensions.cs
@@ -9,5 +9,9 @@ namespace AElf
         {
             return BitConverter.IsLittleEndian ? BitConverter.GetBytes(number).Reverse().ToArray() : BitConverter.GetBytes(number);
         }
+        public static byte[] DumpByteArray(this int n)
+        {
+            return BitConverter.GetBytes(n);
+        }
     }
 }

--- a/test/AElf.Types.Tests/Extensions/ExtensionTests.cs
+++ b/test/AElf.Types.Tests/Extensions/ExtensionTests.cs
@@ -39,7 +39,7 @@ namespace AElf.Types.Tests.Extensions
             byteArray1.ShouldNotBe(null);
 
             //hash
-            var hash = iNumber.ComputeHash();
+            var hash = iNumber.ToHash();
             hash.ShouldNotBe(null);
         }
 


### PR DESCRIPTION
1.create 'ByteStringExtensions' and move 'ToHex(this ByteString bytes, bool withPrefix = false)' to the class
2.rename ComputeHash to ToHash 
3.move 'DumpByteArray(this int n)' to 'NumbericExtensions'