### PR TITLE
Fix state conflict and NotLink bug.

### DIFF
--- a/src/AElf.Kernel.Core/Blockchain/Domain/IChainManager.cs
+++ b/src/AElf.Kernel.Core/Blockchain/Domain/IChainManager.cs
@@ -176,15 +176,12 @@ namespace AElf.Kernel.Blockchain.Domain
                 }
                 else
                 {
-                    if (chainBlockLink.Height <= chain.LongestChainHeight)
+                    //check database to ensure whether it can be a branch
+                    var previousChainBlockLink = await this.GetChainBlockLinkAsync(chainBlockLink.PreviousBlockHash);
+                    if (previousChainBlockLink != null && previousChainBlockLink.IsLinked)
                     {
-                        //check database to ensure whether it can be a branch
-                        var previousChainBlockLink = await this.GetChainBlockLinkAsync(chainBlockLink.PreviousBlockHash);
-                        if (previousChainBlockLink != null && previousChainBlockLink.IsLinked)
-                        {
-                            chain.Branches[previousChainBlockLink.BlockHash.ToStorageKey()] = previousChainBlockLink.Height;
-                            continue;
-                        }
+                        chain.Branches[previousChainBlockLink.BlockHash.ToStorageKey()] = previousChainBlockLink.Height;
+                        continue;
                     }
 
                     chain.NotLinkedBlocks[previousHash] = blockHash;
@@ -219,7 +216,7 @@ namespace AElf.Kernel.Blockchain.Domain
                 if (chainBlockLink == null || chainBlockLink.IsIrreversibleBlock)
                     break;
                 if (!chainBlockLink.IsLinked)
-                    throw new InvalidOperationException("should not set an unlinked block as irreversible block");
+                    throw new InvalidOperationException($"should not set an unlinked block as irreversible block, height: {chainBlockLink.Height}, hash: {chainBlockLink.BlockHash}");
                 chainBlockLink.IsIrreversibleBlock = true;
                 links.Push(chainBlockLink);
                 irreversibleBlockHash = chainBlockLink.PreviousBlockHash;

--- a/src/AElf.Kernel.Core/SmartContract/Domain/IBlockchainStateManager.cs
+++ b/src/AElf.Kernel.Core/SmartContract/Domain/IBlockchainStateManager.cs
@@ -96,6 +96,8 @@ namespace AElf.Kernel.SmartContract.Domain
                         {
                             //not found value in block state sets. for example, best chain is 100, blockHeight is 105,
                             //it will find 105 ~ 101 block state set. so the value could only be the best chain state value.
+                            // retry versioned state in case conflict of get state during merging  
+                            bestChainState = await _versionedStates.GetAsync(key);
                             value = bestChainState.Value;
                         }
                     }
@@ -124,6 +126,13 @@ namespace AElf.Kernel.SmartContract.Domain
                     {
                         blockStateSet = null;
                     }
+                }
+                
+                if (value == null)
+                {
+                    // retry versioned state in case conflict of get state during merging  
+                    bestChainState = await _versionedStates.GetAsync(key);
+                    value = bestChainState?.Value;
                 }
             }
 

--- a/src/AElf.Kernel.SmartContractExecution/Application/BlockchainExecutingService.cs
+++ b/src/AElf.Kernel.SmartContractExecution/Application/BlockchainExecutingService.cs
@@ -135,7 +135,7 @@ namespace AElf.Kernel.SmartContractExecution.Application
             }
             catch (BlockValidationException ex)
             {
-                if (!(ex.InnerException is ValidateNextTimeBlockValidationException) || successLinks.Count == 0)
+                if (!(ex.InnerException is ValidateNextTimeBlockValidationException))
                 {
                     await _chainManager.RemoveLongestBranchAsync(chain);
                     throw;
@@ -150,6 +150,13 @@ namespace AElf.Kernel.SmartContractExecution.Application
                 throw;
             }
 
+            if (successLinks.Count == 0)
+            {
+                Logger.LogWarning("No block execution succeed in this branch.");
+                await _chainManager.RemoveLongestBranchAsync(chain);
+                return null;
+            }
+            
             await SetBestChainAsync(successLinks, chain);
             
             Logger.LogInformation(


### PR DESCRIPTION
- [x] State conflict bug: Get state during state merging, between versioned state and block state, because of multi-threads.
- [x] NotLink bug: It would be set NotLinked If a new block is attached after longest chain switched(because of failed execution), but in `ChainBlockLinkStore` it can be linked actually.
- [x] Improve: Switch longest chain if no block is executable on old longest chain.