### PR TITLE
[WIP] Do not overwrite contracts after patching, save as separate file

### DIFF
--- a/AElf.Contract.Tools.targets
+++ b/AElf.Contract.Tools.targets
@@ -71,7 +71,7 @@
     <!-- Move dlls before codecov injection in travis -->
     <Target Name="CopyNonCodeCovContractDll" AfterTargets="PatchContractCode">
         <Copy Condition="'$(IsContract)' != '' AND '$(IsContract)'" 
-              SourceFiles="$(TargetDir)$(TargetName).dll" 
+              SourceFiles="$(TargetDir)$(TargetName).dll.patched" 
               DestinationFolder="../../test/AElf.Runtime.CSharp.Tests/contracts"
               SkipUnchangedFiles="true" />
     </Target>

--- a/src/AElf.Contracts.Deployer/Program.cs
+++ b/src/AElf.Contracts.Deployer/Program.cs
@@ -11,8 +11,8 @@ namespace AElf.Contracts.Deployer
             var sourceDllPath = args[0];
             var code = File.ReadAllBytes(sourceDllPath);
             
-            // Overwrite
-            File.WriteAllBytes(sourceDllPath, ContractPatcher.Patch(code));
+            // Save as
+            File.WriteAllBytes(sourceDllPath + ".patched", ContractPatcher.Patch(code));
         }
     }
 }

--- a/test/AElf.Runtime.CSharp.Tests/ContractAuditorTests.cs
+++ b/test/AElf.Runtime.CSharp.Tests/ContractAuditorTests.cs
@@ -74,7 +74,7 @@ namespace AElf.Runtime.CSharp.Tests
             // Load the DLL's from contracts folder to prevent codecov injection
             foreach (var contractPath in _contracts.Select(c => _contractDllDir + c.Module.ToString()))
             {
-                Should.NotThrow(()=>_auditorFixture.Audit(ReadCode(contractPath)));
+                Should.NotThrow(()=>_auditorFixture.Audit(ReadCode(contractPath + ".patched")));
             }
         }
 

--- a/test/AElf.Runtime.CSharp.Tests/ContractAuditorTests.cs
+++ b/test/AElf.Runtime.CSharp.Tests/ContractAuditorTests.cs
@@ -86,7 +86,7 @@ namespace AElf.Runtime.CSharp.Tests
         public void CheckBadContract_ForFindings()
         {
             var findings = Should.Throw<InvalidCodeException>(
-                ()=>_auditorFixture.Audit(ReadCode(_contractDllDir + typeof(BadContract.BadContract).Module)))
+                ()=>_auditorFixture.Audit(ReadCode(_contractDllDir + typeof(BadContract.BadContract).Module + ".patched")))
                 .Findings;
             
             // Random usage

--- a/test/AElf.Runtime.CSharp.Tests/ContractPolicyTests.cs
+++ b/test/AElf.Runtime.CSharp.Tests/ContractPolicyTests.cs
@@ -94,8 +94,8 @@ namespace AElf.Runtime.CSharp
 
         public ContractPolicyTests()
         {
-            _systemContractCode = ReadCode(_contractDllDir + typeof(BasicContractZero).Module);
-            _badContractCode = ReadCode(_contractDllDir + typeof(BadContract).Module);
+            _systemContractCode = ReadCode(_contractDllDir + typeof(BasicContractZero).Module + ".patched");
+            _badContractCode = ReadCode(_contractDllDir + typeof(BadContract).Module + ".patched");
         }
 
         [Fact]

--- a/test/AElf.Runtime.CSharp.Tests/contracts/.gitignore
+++ b/test/AElf.Runtime.CSharp.Tests/contracts/.gitignore
@@ -1,2 +1,2 @@
-*.dll
+*.patched
 


### PR DESCRIPTION
Debugging contracts is not possible since additional instructions are added by patching and contract DLL is no longer same as the C# code.

Overwriting is disabled when patching; instead, patched DLL is saved with `.patched` extension, it will be possible to debug contracts this way. However, if we want to deploy with code checking enabled, we need to deploy the DLL with `.patched` extension.