### PR TITLE
[WIP] Fix GetNodes in GrpcServerService & Add RemoveEvilNode method to Election Contract

### DIFF
--- a/contract/AElf.Contracts.Election/ElectionContractState.cs
+++ b/contract/AElf.Contracts.Election/ElectionContractState.cs
@@ -81,5 +81,7 @@ namespace AElf.Contracts.Election
         /// Initial pubkey -> Newest pubkey
         /// </summary>
         public MappedState<string, string> InitialToNewestPubkeyMap { get; set; }
+
+        public SingletonState<Address> EmergencyResponseOrganizationAddress { get; set; }
     }
 }

--- a/contract/AElf.Contracts.Election/ElectionContract_Maintainence.cs
+++ b/contract/AElf.Contracts.Election/ElectionContract_Maintainence.cs
@@ -433,6 +433,13 @@ namespace AElf.Contracts.Election
             return new Empty();
         }
 
+        public override Empty SetEmergencyResponseOrganizationAddress(Address input)
+        {
+            Assert(Context.Sender == GetParliamentDefaultAddress(), "No permission.");
+            State.EmergencyResponseOrganizationAddress.Value = input;
+            return new Empty();
+        }
+
         private void CreateEmergencyResponseOrganization()
         {
             var createOrganizationInput = new CreateOrganizationInput

--- a/contract/AElf.Contracts.Election/ElectionContract_Maintainence.cs
+++ b/contract/AElf.Contracts.Election/ElectionContract_Maintainence.cs
@@ -50,7 +50,10 @@ namespace AElf.Contracts.Election
 
             State.Initialized.Value = true;
 
-            CreateEmergencyResponseOrganization(new Empty());
+            if (Context.Sender == Context.GetZeroSmartContractAddress())
+            {
+                CreateEmergencyResponseOrganization(new Empty());
+            }
 
             return new Empty();
         }
@@ -428,7 +431,9 @@ namespace AElf.Contracts.Election
         {
             Assert(State.EmergencyResponseOrganizationAddress.Value == null,
                 "Emergency Response Organization already created.");
-            Assert(Context.Sender == GetParliamentDefaultAddress(), "No permission.");
+            Assert(
+                Context.Sender == GetParliamentDefaultAddress() ||
+                Context.Sender == Context.GetZeroSmartContractAddress(), "No permission.");
 
             var createOrganizationInput = new CreateOrganizationInput
             {

--- a/contract/AElf.Contracts.Election/ElectionContract_Maintainence.cs
+++ b/contract/AElf.Contracts.Election/ElectionContract_Maintainence.cs
@@ -50,7 +50,7 @@ namespace AElf.Contracts.Election
 
             State.Initialized.Value = true;
 
-            CreateEmergencyResponseOrganizationIfNeeded();
+            CreateEmergencyResponseOrganization(new Empty());
 
             return new Empty();
         }
@@ -412,7 +412,6 @@ namespace AElf.Contracts.Election
 
         public override Empty RemoveEvilNode(StringValue input)
         {
-            CreateEmergencyResponseOrganizationIfNeeded();
             Assert(Context.Sender == State.EmergencyResponseOrganizationAddress.Value, "No permission.");
             UpdateCandidateInformation(new UpdateCandidateInformationInput
             {
@@ -425,18 +424,11 @@ namespace AElf.Contracts.Election
         /// <summary>
         /// Create a Parliament Organization to handle matters of urgency.
         /// </summary>
-        private void CreateEmergencyResponseOrganizationIfNeeded()
+        public override Empty CreateEmergencyResponseOrganization(Empty input)
         {
-            if (State.EmergencyResponseOrganizationAddress.Value != null)
-            {
-                return;
-            }
-
-            if (State.ParliamentContract.Value == null)
-            {
-                State.ParliamentContract.Value =
-                    Context.GetContractAddressByName(SmartContractConstants.ParliamentContractSystemName);
-            }
+            Assert(State.EmergencyResponseOrganizationAddress.Value == null,
+                "Emergency Response Organization already created.");
+            Assert(Context.Sender == GetParliamentDefaultAddress(), "No permission.");
 
             var createOrganizationInput = new CreateOrganizationInput
             {
@@ -454,6 +446,8 @@ namespace AElf.Contracts.Election
 
             State.EmergencyResponseOrganizationAddress.Value =
                 State.ParliamentContract.CalculateOrganizationAddress.Call(createOrganizationInput);
+
+            return new Empty();
         }
 
         private string GetNewestPubkey(string pubkey)

--- a/contract/AElf.Contracts.Election/ElectionContract_Maintainence.cs
+++ b/contract/AElf.Contracts.Election/ElectionContract_Maintainence.cs
@@ -50,11 +50,6 @@ namespace AElf.Contracts.Election
 
             State.Initialized.Value = true;
 
-            if (Context.Sender == Context.GetZeroSmartContractAddress())
-            {
-                CreateEmergencyResponseOrganization(new Empty());
-            }
-
             return new Empty();
         }
 
@@ -431,10 +426,15 @@ namespace AElf.Contracts.Election
         {
             Assert(State.EmergencyResponseOrganizationAddress.Value == null,
                 "Emergency Response Organization already created.");
-            Assert(
-                Context.Sender == GetParliamentDefaultAddress() ||
-                Context.Sender == Context.GetZeroSmartContractAddress(), "No permission.");
+            Assert(Context.Sender == GetParliamentDefaultAddress(), "No permission.");
 
+            CreateEmergencyResponseOrganization();
+
+            return new Empty();
+        }
+
+        private void CreateEmergencyResponseOrganization()
+        {
             var createOrganizationInput = new CreateOrganizationInput
             {
                 ProposalReleaseThreshold = new ProposalReleaseThreshold
@@ -451,8 +451,6 @@ namespace AElf.Contracts.Election
 
             State.EmergencyResponseOrganizationAddress.Value =
                 State.ParliamentContract.CalculateOrganizationAddress.Call(createOrganizationInput);
-
-            return new Empty();
         }
 
         private string GetNewestPubkey(string pubkey)

--- a/contract/AElf.Contracts.Parliament/Parliament.cs
+++ b/contract/AElf.Contracts.Parliament/Parliament.cs
@@ -310,6 +310,8 @@ namespace AElf.Contracts.Parliament
 
         public override Empty CreateEmergencyResponseOrganization(Empty input)
         {
+            Assert(State.EmergencyResponseOrganizationAddress.Value == null,
+                "Emergency Response Organization already exists.");
             AssertSenderAddressWith(State.DefaultOrganizationAddress.Value);
             CreateEmergencyResponseOrganization();
             return new Empty();

--- a/contract/AElf.Contracts.Parliament/Parliament.cs
+++ b/contract/AElf.Contracts.Parliament/Parliament.cs
@@ -156,7 +156,9 @@ namespace AElf.Contracts.Parliament
 
         public override Address CreateOrganization(CreateOrganizationInput input)
         {
-            Assert(ValidateAddressInWhiteList(Context.Sender) || ValidateParliamentMemberAuthority(Context.Sender),
+            Assert(
+                ValidateAddressInWhiteList(Context.Sender) || ValidateParliamentMemberAuthority(Context.Sender) ||
+                State.DefaultOrganizationAddress.Value == Context.Sender,
                 "Unauthorized to create organization.");
             var organizationAddress = CreateNewOrganization(input);
 

--- a/contract/AElf.Contracts.Parliament/Parliament.cs
+++ b/contract/AElf.Contracts.Parliament/Parliament.cs
@@ -58,14 +58,14 @@ namespace AElf.Contracts.Parliament
 
         public override BoolValue ValidateAddressIsParliamentMember(Address address)
         {
-            return new BoolValue {Value = ValidateParliamentMemberAuthority(address)};
+            return new BoolValue { Value = ValidateParliamentMemberAuthority(address) };
         }
 
         public override BoolValue ValidateProposerInWhiteList(ValidateProposerInWhiteListInput input)
         {
-            return new BoolValue {Value = ValidateAddressInWhiteList(input.Proposer)};
+            return new BoolValue { Value = ValidateAddressInWhiteList(input.Proposer) };
         }
-        
+
         public override ProposerWhiteList GetProposerWhiteList(Empty input)
         {
             var res = new ProposerWhiteList();
@@ -76,7 +76,7 @@ namespace AElf.Contracts.Parliament
 
         public override BoolValue ValidateOrganizationExist(Address input)
         {
-            return new BoolValue {Value = State.Organizations[input] != null};
+            return new BoolValue { Value = State.Organizations[input] != null };
         }
 
         public override ProposalIdList GetNotVotedProposals(ProposalIdList input)
@@ -244,7 +244,7 @@ namespace AElf.Contracts.Parliament
             Context.SendVirtualInlineBySystemContract(
                 CalculateVirtualHash(organization.OrganizationHash, organization.CreationToken), proposalInfo.ToAddress,
                 proposalInfo.ContractMethodName, proposalInfo.Params);
-            Context.Fire(new ProposalReleased {ProposalId = proposalId});
+            Context.Fire(new ProposalReleased { ProposalId = proposalId });
             State.Proposals.Remove(proposalId);
 
             return new Empty();
@@ -297,13 +297,25 @@ namespace AElf.Contracts.Parliament
             foreach (var proposalId in input.ProposalIds)
             {
                 var proposal = State.Proposals[proposalId];
-                if (proposal == null || !CheckProposalNotExpired(proposal)) 
+                if (proposal == null || !CheckProposalNotExpired(proposal))
                     continue;
                 Approve(proposalId);
                 Context.LogDebug(() => $"Proposal {proposalId} approved by {Context.Sender}");
             }
 
             return new Empty();
+        }
+
+        public override Empty CreateEmergencyResponseOrganization(Empty input)
+        {
+            AssertSenderAddressWith(State.DefaultOrganizationAddress.Value);
+            CreateEmergencyResponseOrganization();
+            return new Empty();
+        }
+
+        public override Address GetEmergencyResponseOrganizationAddress(Empty input)
+        {
+            return State.EmergencyResponseOrganizationAddress.Value;
         }
     }
 }

--- a/contract/AElf.Contracts.Parliament/ParliamentState.cs
+++ b/contract/AElf.Contracts.Parliament/ParliamentState.cs
@@ -22,5 +22,7 @@ namespace AElf.Contracts.Parliament
 
         public SingletonState<ProposerWhiteList> ProposerWhiteList { get; set; }
         public SingletonState<AuthorityInfo> MethodFeeController { get; set; }
+
+        public SingletonState<Address> EmergencyResponseOrganizationAddress { get; set; }
     }
 }

--- a/contract/AElf.Contracts.Parliament/Parliament_Helper.cs
+++ b/contract/AElf.Contracts.Parliament/Parliament_Helper.cs
@@ -202,7 +202,7 @@ namespace AElf.Contracts.Parliament
         {
             return Context.GenerateId(Context.Self, input.Token ?? HashHelper.ComputeFrom(input));
         }
-        
+
         private Hash CreateNewProposal(CreateProposalInput input)
         {
             Hash proposalId = GenerateProposalId(input);
@@ -221,7 +221,7 @@ namespace AElf.Contracts.Parliament
             Assert(State.Proposals[proposalId] == null, "Proposal already exists.");
             State.Proposals[proposalId] = proposal;
             Context.Fire(new ProposalCreated
-                {ProposalId = proposalId, OrganizationAddress = input.OrganizationAddress});
+                { ProposalId = proposalId, OrganizationAddress = input.OrganizationAddress });
             return proposalId;
         }
 
@@ -265,12 +265,30 @@ namespace AElf.Contracts.Parliament
                 OrganizationHash = organizationHash
             };
         }
-        
+
         private Hash CalculateVirtualHash(Hash organizationHash, Hash creationToken)
         {
             return creationToken == null
                 ? organizationHash
                 : HashHelper.ConcatAndCompute(organizationHash, creationToken);
+        }
+
+        private void CreateEmergencyResponseOrganization()
+        {
+            var createOrganizationInput = new CreateOrganizationInput
+            {
+                ProposalReleaseThreshold = new ProposalReleaseThreshold
+                {
+                    MinimalApprovalThreshold = 9000,
+                    MinimalVoteThreshold = 9000,
+                    MaximalAbstentionThreshold = 1000,
+                    MaximalRejectionThreshold = 1000
+                },
+                ProposerAuthorityRequired = false,
+                ParliamentMemberProposingAllowed = true
+            };
+
+            State.EmergencyResponseOrganizationAddress.Value = CreateOrganization(createOrganizationInput);
         }
     }
 }

--- a/protobuf/election_contract.proto
+++ b/protobuf/election_contract.proto
@@ -93,6 +93,9 @@ service ElectionContract {
     
     rpc RemoveEvilNode (google.protobuf.StringValue) returns (google.protobuf.Empty) {
     }
+    
+    rpc CreateEmergencyResponseOrganization (google.protobuf.Empty) returns (google.protobuf.Empty) {
+    }
 
     // Views
     

--- a/protobuf/election_contract.proto
+++ b/protobuf/election_contract.proto
@@ -91,6 +91,11 @@ service ElectionContract {
     rpc SetCandidateAdmin (SetCandidateAdminInput) returns (google.protobuf.Empty) {
     }
     
+    rpc RemoveEvilNode (google.protobuf.StringValue) returns (google.protobuf.Empty) {
+    }
+
+    // Views
+    
     // Get all candidates’ public keys.
     rpc GetCandidates (google.protobuf.Empty) returns (PubkeyList) {
         option (aelf.is_view) = true;

--- a/protobuf/election_contract.proto
+++ b/protobuf/election_contract.proto
@@ -96,6 +96,9 @@ service ElectionContract {
     
     rpc CreateEmergencyResponseOrganization (google.protobuf.Empty) returns (google.protobuf.Empty) {
     }
+    
+    rpc SetEmergencyResponseOrganizationAddress (aelf.Address) returns (google.protobuf.Empty) {
+    }
 
     // Views
     

--- a/protobuf/election_contract.proto
+++ b/protobuf/election_contract.proto
@@ -93,12 +93,6 @@ service ElectionContract {
     
     rpc RemoveEvilNode (google.protobuf.StringValue) returns (google.protobuf.Empty) {
     }
-    
-    rpc CreateEmergencyResponseOrganization (google.protobuf.Empty) returns (google.protobuf.Empty) {
-    }
-    
-    rpc SetEmergencyResponseOrganizationAddress (aelf.Address) returns (google.protobuf.Empty) {
-    }
 
     // Views
     

--- a/protobuf/parliament_contract.proto
+++ b/protobuf/parliament_contract.proto
@@ -72,7 +72,7 @@ service ParliamentContract {
 message CreateOrganizationInput {
     // The threshold for releasing the proposal.
     acs3.ProposalReleaseThreshold proposal_release_threshold = 1;
-    // Setting this to true can allow anyone to create proposals.
+    // Setting this to false will allow anyone creating proposals.
     bool proposer_authority_required = 2;
     // Setting this to true can allow parliament member to create proposals.
     bool parliament_member_proposing_allowed = 3;

--- a/protobuf/parliament_contract.proto
+++ b/protobuf/parliament_contract.proto
@@ -33,6 +33,10 @@ service ParliamentContract {
     rpc CreateOrganizationBySystemContract(CreateOrganizationBySystemContractInput) returns (aelf.Address){
     }
 
+    // Creates an organization to handle emergency events.
+    rpc CreateEmergencyResponseOrganization (google.protobuf.Empty) returns (google.protobuf.Empty) {
+    }
+
     // Get the organization according to the organization address.
     rpc GetOrganization (aelf.Address) returns (Organization) {
         option (aelf.is_view) = true;
@@ -65,6 +69,10 @@ service ParliamentContract {
     
     // Calculates with input and return the organization address.
     rpc CalculateOrganizationAddress(CreateOrganizationInput) returns (aelf.Address){
+        option (aelf.is_view) = true;
+    }
+    
+    rpc GetEmergencyResponseOrganizationAddress (google.protobuf.Empty) returns (aelf.Address) {
         option (aelf.is_view) = true;
     }
 }

--- a/src/AElf.OS.Network.Grpc/GrpcConstants.cs
+++ b/src/AElf.OS.Network.Grpc/GrpcConstants.cs
@@ -19,5 +19,7 @@ namespace AElf.OS.Network.Grpc
         public const int MaxSendBlockCountLimit = 50;
 
         public const string DefaultTlsCommonName = "aelf";
+
+        public const int DefaultDiscoveryMaxNodesToResponse = 10;
     }
 }

--- a/src/AElf.OS.Network.Grpc/Service/GrpcServerService.cs
+++ b/src/AElf.OS.Network.Grpc/Service/GrpcServerService.cs
@@ -336,12 +336,13 @@ namespace AElf.OS.Network.Grpc
             if (request == null)
                 return new NodeList();
 
-            Logger.LogDebug($"Peer {context.GetPeerInfo()} requested {request.MaxCount} nodes.");
+            var nodesCount = Math.Min(request.MaxCount, GrpcConstants.DefaultDiscoveryMaxNodesToResponse);
+            Logger.LogDebug($"Peer {context.GetPeerInfo()} requested {nodesCount} nodes.");
 
             NodeList nodes;
             try
             {
-                nodes = await _nodeManager.GetRandomNodesAsync(request.MaxCount);
+                nodes = await _nodeManager.GetRandomNodesAsync(nodesCount);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
# Nodes do not enforce constraints on all API requests

We checked the implementations of services defined in "peer_service.proto" file and found that only method `GetNodes` need a constraint.

# Malicious miners can avoid removal until elections

In order to remove an evil node, we proposed to create a Parliament Organization with the following settings:

| Parameter | Value | Description |
|  ----  | ----  | ---- |
|ProposalReleaseThreshold.MinimalApprovalThreshold|9000|Proposal can be released if 90% of the Parliament members agreed.|
|ProposalReleaseThreshold.MinimalVoteThreshold|9000|Proposal releasement need more than 90% of the Parliament members' votes|
|ProposalReleaseThreshold.MaximalAbstentionThreshold|1000|Proposal will be denied if more than 10% of the Parliament members vote as Abstence|
|ProposalReleaseThreshold.MaximalRejectionThreshold|1000|Proposal will be denied if more than 10% of the Parliament members vote as Reject|
|ProposerAuthorityRequired|false|Disable proposer authority, this setting is the same as the Parliament Default Origanization|
|ParliamentMemberProposingAllowed|true|Anyone from the Parliament can propose a proposal|

We call this organization Emergency Response Organization which will handle matters of urgency like evil node detected, 90% of the Parliament members can propose to remove the evil node asap in this case.

Also, we add `RemoveEvilNode` method to the Election Contract to deal with the removing stuff.
