### PR TITLE
[WIP] Verify code check can be passed for deployed contracts.

### DIFF
--- a/contract/AElf.Contracts.Genesis/BasicContractZero.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZero.cs
@@ -80,6 +80,11 @@ namespace AElf.Contracts.Genesis
             return State.CodeCheckController.Value;
         }
 
+        public override ContractCodeHashList GetContractCodeHashListByDeployingBlockHeight(Int64Value input)
+        {
+            return State.ContractCodeHashListMap[input.Value];
+        }
+
         #endregion Views
 
         #region Actions

--- a/contract/AElf.Contracts.Genesis/BasicContractZeroState.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZeroState.cs
@@ -14,22 +14,24 @@ namespace AElf.Contracts.Genesis
         public MappedState<Hash, SmartContractRegistration> SmartContractRegistrations { get; set; }
 
         public MappedState<Hash, Address> NameAddressMapping { get; set; }
-        
+
         public MappedState<Hash, ContractProposingInput> ContractProposingInputMap { get; set; }
-        
+
         /// <summary>
         /// Genesis owner controls contract deployment if <see cref="ContractDeploymentAuthorityRequired"/> is true.
         /// </summary>
         public SingletonState<AuthorityInfo> ContractDeploymentController { get; set; }
-        
+
         public SingletonState<AuthorityInfo> CodeCheckController { get; set; }
-        
+
         public SingletonState<bool> ContractDeploymentAuthorityRequired { get; set; }
-        
+
         public SingletonState<bool> Initialized { get; set; }
 
         public MappedState<string, MethodFees> TransactionFees { get; set; }
 
         public SingletonState<AuthorityInfo> MethodFeeController { get; set; }
+
+        public MappedState<long, ContractCodeHashList> ContractCodeHashListMap { get; set; }
     }
 }

--- a/contract/AElf.Contracts.Genesis/BasicContractZero_Helper.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZero_Helper.cs
@@ -67,6 +67,11 @@ namespace AElf.Contracts.Genesis
             if (name != null)
                 State.NameAddressMapping[name] = contractAddress;
 
+            var contractCodeHashList =
+                State.ContractCodeHashListMap[Context.CurrentHeight] ?? new ContractCodeHashList();
+            contractCodeHashList.Value.Add(codeHash);
+            State.ContractCodeHashListMap[Context.CurrentHeight] = contractCodeHashList;
+
             return contractAddress;
         }
         

--- a/protobuf/acs0.proto
+++ b/protobuf/acs0.proto
@@ -91,7 +91,7 @@ service ACS0 {
         option (aelf.is_view) = true;
     }
 
-    rpc GetContractCodeHashListByDeployBlockHeight (google.protobuf.Int64Value) returns (ContractCodeHashList) {
+    rpc GetContractCodeHashListByDeployingBlockHeight (google.protobuf.Int64Value) returns (ContractCodeHashList) {
         option (aelf.is_view) = true;
     }
 }

--- a/protobuf/acs0.proto
+++ b/protobuf/acs0.proto
@@ -228,3 +228,7 @@ message ReleaseContractInput {
 message ContractCodeHashList {
     repeated aelf.Hash value = 1;
 }
+
+message ContractCodeHashMap {
+    map<int64, ContractCodeHashList> value = 1;
+}

--- a/protobuf/acs0.proto
+++ b/protobuf/acs0.proto
@@ -90,6 +90,10 @@ service ACS0 {
     rpc GetSmartContractRegistrationByCodeHash (aelf.Hash) returns (aelf.SmartContractRegistration) {
         option (aelf.is_view) = true;
     }
+
+    rpc GetContractCodeHashListByDeployBlockHeight (google.protobuf.Int64Value) returns (ContractCodeHashList) {
+        option (aelf.is_view) = true;
+    }
 }
 
 message ContractInfo
@@ -219,4 +223,8 @@ message ReleaseContractInput {
     aelf.Hash proposal_id = 1;
     // The id of the proposed contract.
     aelf.Hash proposed_contract_input_hash = 2;
+}
+
+message ContractCodeHashList {
+    repeated aelf.Hash value = 1;
 }

--- a/src/AElf.Kernel.CodeCheck/AElf.Kernel.CodeCheck.csproj
+++ b/src/AElf.Kernel.CodeCheck/AElf.Kernel.CodeCheck.csproj
@@ -14,9 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ContractMessage Include="..\..\protobuf\acs0.proto">
+        <ContractStub Include="..\..\protobuf\acs0.proto">
             <Link>Protobuf\Proto\acs0.proto</Link>
-        </ContractMessage>
+        </ContractStub>
         <ContractMessage Include="..\..\protobuf\acs3.proto">
             <Link>Protobuf\Proto\acs3.proto</Link>
         </ContractMessage>

--- a/src/AElf.Kernel.CodeCheck/Application/CodeCheckService.cs
+++ b/src/AElf.Kernel.CodeCheck/Application/CodeCheckService.cs
@@ -28,7 +28,7 @@ namespace AElf.Kernel.CodeCheck.Application
         public async Task<bool> PerformCodeCheckAsync(byte[] code, Hash blockHash, long blockHeight, int category, bool isSystemContract)
         {
             if (!_codeCheckOptions.CodeCheckEnabled)
-                return false;
+                return true;
 
             var requiredAcs =
                 await _requiredAcsProvider.GetRequiredAcsInContractsAsync(blockHash, blockHeight);

--- a/src/AElf.Kernel.CodeCheck/Application/CodeCheckValidationProvider.cs
+++ b/src/AElf.Kernel.CodeCheck/Application/CodeCheckValidationProvider.cs
@@ -45,7 +45,7 @@ namespace AElf.Kernel.CodeCheck.Application
                 BlockHash = blockHash,
                 BlockHeight = block.Header.Height,
                 ContractAddress = genesisContractAddress
-            }).GetContractCodeHashListByDeployBlockHeight.CallAsync(new Int64Value { Value = block.Header.Height });
+            }).GetContractCodeHashListByDeployingBlockHeight.CallAsync(new Int64Value { Value = block.Header.Height });
 
             return codeHashList.Value.All(codeHash => _checkedCodeHashProvider.IsCodeHashExists(new BlockIndex
             {

--- a/src/AElf.Kernel.CodeCheck/Application/CodeCheckValidationProvider.cs
+++ b/src/AElf.Kernel.CodeCheck/Application/CodeCheckValidationProvider.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using System.Threading.Tasks;
+using AElf.CSharp.Core.Extension;
+using AElf.Kernel.Blockchain.Application;
+using AElf.Kernel.SmartContract.Application;
+using AElf.Standards.ACS0;
+using Google.Protobuf.WellKnownTypes;
+
+namespace AElf.Kernel.CodeCheck.Application
+{
+    internal class CodeCheckValidationProvider : IBlockValidationProvider
+    {
+        private readonly ISmartContractAddressService _smartContractAddressService;
+        private readonly IContractReaderFactory<ACS0Container.ACS0Stub> _contractReaderFactory;
+        private readonly ICheckedCodeHashProvider _checkedCodeHashProvider;
+
+        public CodeCheckValidationProvider(ISmartContractAddressService smartContractAddressService,
+            IContractReaderFactory<ACS0Container.ACS0Stub> contractReaderFactory,
+            ICheckedCodeHashProvider checkedCodeHashProvider)
+        {
+            _smartContractAddressService = smartContractAddressService;
+            _contractReaderFactory = contractReaderFactory;
+            _checkedCodeHashProvider = checkedCodeHashProvider;
+        }
+
+        public Task<bool> ValidateBeforeAttachAsync(IBlock block)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> ValidateBlockBeforeExecuteAsync(IBlock block)
+        {
+            return Task.FromResult(true);
+        }
+
+        public async Task<bool> ValidateBlockAfterExecuteAsync(IBlock block)
+        {
+            var genesisContractAddress = _smartContractAddressService.GetZeroSmartContractAddress();
+            var deployedBloom = new ContractDeployed().ToLogEvent(genesisContractAddress).GetBloom();
+            if (!deployedBloom.IsIn(new Bloom(block.Header.Bloom.ToByteArray()))) return true;
+
+            var blockHash = block.GetHash();
+            var codeHashList = await _contractReaderFactory.Create(new ContractReaderContext
+            {
+                BlockHash = blockHash,
+                BlockHeight = block.Header.Height,
+                ContractAddress = genesisContractAddress
+            }).GetContractCodeHashListByDeployBlockHeight.CallAsync(new Int64Value { Value = block.Header.Height });
+
+            return codeHashList.Value.All(codeHash => _checkedCodeHashProvider.IsCodeHashExists(new BlockIndex
+            {
+                BlockHash = blockHash,
+                BlockHeight = block.Header.Height
+            }, codeHash));
+        }
+    }
+}

--- a/src/AElf.Kernel.CodeCheck/Application/ICheckedCodeHashProvider.cs
+++ b/src/AElf.Kernel.CodeCheck/Application/ICheckedCodeHashProvider.cs
@@ -2,6 +2,8 @@ using System.Threading.Tasks;
 using AElf.Kernel.SmartContract.Application;
 using AElf.Standards.ACS0;
 using AElf.Types;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Volo.Abp.DependencyInjection;
 
 namespace AElf.Kernel.CodeCheck.Application
@@ -16,16 +18,19 @@ namespace AElf.Kernel.CodeCheck.Application
     internal class CheckedCodeHashProvider : BlockExecutedDataBaseProvider<ContractCodeHashMap>,
         ICheckedCodeHashProvider, ISingletonDependency
     {
+        public ILogger<CheckedCodeHashProvider> Logger { get; set; }
+
         public CheckedCodeHashProvider(
             ICachedBlockchainExecutedDataService<ContractCodeHashMap> cachedBlockchainExecutedDataService) :
             base(cachedBlockchainExecutedDataService)
         {
-
+            Logger = NullLogger<CheckedCodeHashProvider>.Instance;
         }
 
         public async Task AddCodeHashAsync(BlockIndex blockIndex, Hash codeHash)
         {
-            var codeHashMap = GetBlockExecutedData(blockIndex);
+            Logger.LogInformation($"Added code hash: {blockIndex}");
+            var codeHashMap = GetBlockExecutedData(blockIndex) ?? new ContractCodeHashMap();
             codeHashMap.TryAdd(blockIndex.BlockHeight, codeHash);
             await AddBlockExecutedDataAsync(blockIndex, codeHashMap);
         }
@@ -33,11 +38,14 @@ namespace AElf.Kernel.CodeCheck.Application
         public bool IsCodeHashExists(BlockIndex blockIndex, Hash codeHash)
         {
             var codeHashMap = GetBlockExecutedData(blockIndex);
-            return codeHashMap.ContainsValue(codeHash);
+            var result = codeHashMap.ContainsValue(codeHash);
+            Logger.LogInformation($"Is {codeHash} exists in height {blockIndex.BlockHeight}: {result}");
+            return result;
         }
 
         public async Task RemoveCodeHashAsync(BlockIndex blockIndex, long libHeight)
         {
+            Logger.LogInformation($"Removing code hash list below height {libHeight}");
             var codeHashMap = GetBlockExecutedData(blockIndex);
             codeHashMap.RemoveValuesBeforeLibHeight(libHeight);
             await AddBlockExecutedDataAsync(blockIndex, codeHashMap);

--- a/src/AElf.Kernel.CodeCheck/Application/ICheckedCodeHashProvider.cs
+++ b/src/AElf.Kernel.CodeCheck/Application/ICheckedCodeHashProvider.cs
@@ -38,6 +38,11 @@ namespace AElf.Kernel.CodeCheck.Application
         public bool IsCodeHashExists(BlockIndex blockIndex, Hash codeHash)
         {
             var codeHashMap = GetBlockExecutedData(blockIndex);
+            if (codeHashMap == null)
+            {
+                return false;
+            }
+
             var result = codeHashMap.ContainsValue(codeHash);
             Logger.LogInformation($"Is {codeHash} exists in height {blockIndex.BlockHeight}: {result}");
             return result;
@@ -47,6 +52,11 @@ namespace AElf.Kernel.CodeCheck.Application
         {
             Logger.LogInformation($"Removing code hash list below height {libHeight}");
             var codeHashMap = GetBlockExecutedData(blockIndex);
+            if (codeHashMap == null)
+            {
+                return;
+            }
+
             codeHashMap.RemoveValuesBeforeLibHeight(libHeight);
             await AddBlockExecutedDataAsync(blockIndex, codeHashMap);
         }

--- a/src/AElf.Kernel.CodeCheck/Application/ICheckedCodeHashProvider.cs
+++ b/src/AElf.Kernel.CodeCheck/Application/ICheckedCodeHashProvider.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using AElf.Kernel.SmartContract.Application;
+using AElf.Standards.ACS0;
+using AElf.Types;
+using Volo.Abp.DependencyInjection;
+
+namespace AElf.Kernel.CodeCheck.Application
+{
+    public interface ICheckedCodeHashProvider
+    {
+        Task AddCodeHashAsync(BlockIndex blockIndex, Hash codeHash);
+        bool IsCodeHashExists(BlockIndex blockIndex, Hash codeHash);
+        Task RemoveCodeHashAsync(BlockIndex blockIndex, long libHeight);
+    }
+
+    internal class CheckedCodeHashProvider : BlockExecutedDataBaseProvider<ContractCodeHashMap>,
+        ICheckedCodeHashProvider, ISingletonDependency
+    {
+        public CheckedCodeHashProvider(
+            ICachedBlockchainExecutedDataService<ContractCodeHashMap> cachedBlockchainExecutedDataService) :
+            base(cachedBlockchainExecutedDataService)
+        {
+
+        }
+
+        public async Task AddCodeHashAsync(BlockIndex blockIndex, Hash codeHash)
+        {
+            var codeHashMap = GetBlockExecutedData(blockIndex);
+            codeHashMap.TryAdd(blockIndex.BlockHeight, codeHash);
+            await AddBlockExecutedDataAsync(blockIndex, codeHashMap);
+        }
+
+        public bool IsCodeHashExists(BlockIndex blockIndex, Hash codeHash)
+        {
+            var codeHashMap = GetBlockExecutedData(blockIndex);
+            return codeHashMap.ContainsValue(codeHash);
+        }
+
+        public async Task RemoveCodeHashAsync(BlockIndex blockIndex, long libHeight)
+        {
+            var codeHashMap = GetBlockExecutedData(blockIndex);
+            codeHashMap.RemoveValuesBeforeLibHeight(libHeight);
+            await AddBlockExecutedDataAsync(blockIndex, codeHashMap);
+        }
+
+        protected override string GetBlockExecutedDataName()
+        {
+            return nameof(ContractCodeHashMap);
+        }
+    }
+}

--- a/src/AElf.Kernel.CodeCheck/CodeCheckAElfModule.cs
+++ b/src/AElf.Kernel.CodeCheck/CodeCheckAElfModule.cs
@@ -1,5 +1,6 @@
+using AElf.Kernel.Blockchain.Application;
+using AElf.Kernel.CodeCheck.Application;
 using AElf.Kernel.CodeCheck.Infrastructure;
-using AElf.Kernel.Proposal;
 using AElf.Kernel.SmartContract.Application;
 using AElf.Modularity;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,8 +12,10 @@ namespace AElf.Kernel.CodeCheck
     {
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
-            context.Services.AddSingleton<IBlocksExecutionSucceededLogEventProcessor, CodeCheckRequiredLogEventProcessor>();
+            context.Services
+                .AddSingleton<IBlocksExecutionSucceededLogEventProcessor, CodeCheckRequiredLogEventProcessor>();
             context.Services.AddSingleton<IContractAuditorContainer, ContractAuditorContainer>();
+            context.Services.AddSingleton<IBlockValidationProvider, CodeCheckValidationProvider>();
         }
     }
 }

--- a/src/AElf.Kernel.CodeCheck/CodeCheckAElfModule.cs
+++ b/src/AElf.Kernel.CodeCheck/CodeCheckAElfModule.cs
@@ -14,6 +14,7 @@ namespace AElf.Kernel.CodeCheck
         {
             context.Services
                 .AddSingleton<IBlocksExecutionSucceededLogEventProcessor, CodeCheckRequiredLogEventProcessor>();
+            //context.Services.AddSingleton<IBlockAcceptedLogEventProcessor, ContractDeployedLogEventProcessor>();
             context.Services.AddSingleton<IContractAuditorContainer, ContractAuditorContainer>();
             context.Services.AddSingleton<IBlockValidationProvider, CodeCheckValidationProvider>();
         }

--- a/src/AElf.Kernel.CodeCheck/CodeCheckRequiredLogEventProcessor.cs
+++ b/src/AElf.Kernel.CodeCheck/CodeCheckRequiredLogEventProcessor.cs
@@ -8,6 +8,8 @@ using AElf.Kernel.CodeCheck.Application;
 using AElf.Kernel.Proposal.Application;
 using AElf.CSharp.Core.Extension;
 using AElf.Kernel.SmartContract.Application;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AElf.Kernel.CodeCheck
 {
@@ -17,6 +19,7 @@ namespace AElf.Kernel.CodeCheck
         private readonly ICodeCheckService _codeCheckService;
         private readonly IProposalService _proposalService;
         private readonly ICheckedCodeHashProvider _checkedCodeHashProvider;
+        public ILogger<CodeCheckRequiredLogEventProcessor> Logger { get; set; }
 
         public CodeCheckRequiredLogEventProcessor(ISmartContractAddressService smartContractAddressService,
             ICodeCheckService codeCheckService, IProposalService proposalService,
@@ -26,6 +29,8 @@ namespace AElf.Kernel.CodeCheck
             _codeCheckService = codeCheckService;
             _proposalService = proposalService;
             _checkedCodeHashProvider = checkedCodeHashProvider;
+
+            Logger = NullLogger<CodeCheckRequiredLogEventProcessor>.Instance;
         }
 
         public override Task<InterestedEvent> GetInterestedEventAsync(IChainContext chainContext)
@@ -43,6 +48,7 @@ namespace AElf.Kernel.CodeCheck
 
         public override Task ProcessAsync(Block block, Dictionary<TransactionResult, List<LogEvent>> logEventsMap)
         {
+            Logger.LogInformation("Start handling CodeCheckRequired log event.");
             foreach (var events in logEventsMap)
             {
                 var transactionResult = events.Key;
@@ -57,6 +63,7 @@ namespace AElf.Kernel.CodeCheck
                             eventData.Code.ToByteArray(),
                             transactionResult.BlockHash, transactionResult.BlockNumber, eventData.Category,
                             eventData.IsSystemContract);
+                        Logger.LogInformation($"Code check result: {codeCheckResult}");
                         if (!codeCheckResult)
                             return;
 

--- a/src/AElf.Kernel.CodeCheck/ContractCodeHashMap.cs
+++ b/src/AElf.Kernel.CodeCheck/ContractCodeHashMap.cs
@@ -1,23 +1,21 @@
-using System.Collections.Generic;
 using System.Linq;
-using AElf.Standards.ACS0;
 using AElf.Types;
 
-namespace AElf.Kernel.CodeCheck
+namespace AElf.Standards.ACS0
 {
-    internal class ContractCodeHashMap : Dictionary<long, ContractCodeHashList>
+    internal partial class ContractCodeHashMap
     {
         public void TryAdd(long blockHeight, Hash codeHash)
         {
-            if (ContainsKey(blockHeight))
+            if (Value.ContainsKey(blockHeight))
             {
-                var value = this[blockHeight];
-                value.Value.Add(codeHash);
-                this[blockHeight] = value;
+                var hashList = Value[blockHeight];
+                hashList.Value.Add(codeHash);
+                Value[blockHeight] = hashList;
             }
             else
             {
-                this[blockHeight] = new ContractCodeHashList
+                Value[blockHeight] = new ContractCodeHashList
                 {
                     Value = { codeHash }
                 };
@@ -26,14 +24,14 @@ namespace AElf.Kernel.CodeCheck
 
         public bool ContainsValue(Hash codeHash)
         {
-            return Values.SelectMany(l => l.Value).Contains(codeHash);
+            return Value.Values.SelectMany(l => l.Value).Contains(codeHash);
         }
 
         public void RemoveValuesBeforeLibHeight(long libHeight)
         {
-            foreach (var key in Keys.Where(k => k <= libHeight))
+            foreach (var key in Value.Keys.Where(k => k <= libHeight))
             {
-                Remove(key);
+                Value.Remove(key);
             }
         }
     }

--- a/src/AElf.Kernel.CodeCheck/ContractCodeHashMap.cs
+++ b/src/AElf.Kernel.CodeCheck/ContractCodeHashMap.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using AElf.Standards.ACS0;
+using AElf.Types;
+
+namespace AElf.Kernel.CodeCheck
+{
+    internal class ContractCodeHashMap : Dictionary<long, ContractCodeHashList>
+    {
+        public void TryAdd(long blockHeight, Hash codeHash)
+        {
+            if (ContainsKey(blockHeight))
+            {
+                var value = this[blockHeight];
+                value.Value.Add(codeHash);
+                this[blockHeight] = value;
+            }
+            else
+            {
+                this[blockHeight] = new ContractCodeHashList
+                {
+                    Value = { codeHash }
+                };
+            }
+        }
+
+        public bool ContainsValue(Hash codeHash)
+        {
+            return Values.SelectMany(l => l.Value).Contains(codeHash);
+        }
+
+        public void RemoveValuesBeforeLibHeight(long libHeight)
+        {
+            foreach (var key in Keys.Where(k => k <= libHeight))
+            {
+                Remove(key);
+            }
+        }
+    }
+}

--- a/src/AElf.Kernel.CodeCheck/ContractDeployedLogEventProcessor.cs
+++ b/src/AElf.Kernel.CodeCheck/ContractDeployedLogEventProcessor.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using AElf.Standards.ACS0;
+using AElf.Kernel.SmartContract.Application;
+using AElf.Types;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using AElf.CSharp.Core.Extension;
+using AElf.Kernel.CodeCheck.Application;
+
+namespace AElf.Kernel.CodeCheck
+{
+    /// <summary>
+    /// Maybe not useful.
+    /// </summary>
+    public class ContractDeployedLogEventProcessor : LogEventProcessorBase, IBlockAcceptedLogEventProcessor
+    {
+        private readonly ICheckedCodeHashProvider _checkedCodeHashProvider;
+        private readonly ISmartContractAddressService _smartContractAddressService;
+        public ILogger<ContractDeployedLogEventProcessor> Logger { get; set; }
+
+        public ContractDeployedLogEventProcessor(ISmartContractAddressService smartContractAddressService,
+            ICheckedCodeHashProvider checkedCodeHashProvider)
+        {
+            _checkedCodeHashProvider = checkedCodeHashProvider;
+            _smartContractAddressService = smartContractAddressService;
+
+            Logger = NullLogger<ContractDeployedLogEventProcessor>.Instance;
+        }
+
+        public override Task<InterestedEvent> GetInterestedEventAsync(IChainContext chainContext)
+        {
+            if (InterestedEvent != null)
+                return Task.FromResult(InterestedEvent);
+
+            var address = _smartContractAddressService.GetZeroSmartContractAddress();
+            if (address == null) return null;
+
+            InterestedEvent = GetInterestedEvent<ContractDeployed>(address);
+
+            return Task.FromResult(InterestedEvent);
+        }
+
+        protected override async Task ProcessLogEventAsync(Block block, LogEvent logEvent)
+        {
+            var eventData = new ContractDeployed();
+            eventData.MergeFrom(logEvent);
+
+            await _checkedCodeHashProvider.AddCodeHashAsync(new BlockIndex
+            {
+                BlockHash = block.GetHash(),
+                BlockHeight = block.Height
+            }, eventData.CodeHash);
+        }
+    }
+}

--- a/src/AElf.Kernel.CodeCheck/NewIrreversibleBlockFoundEventHandler.cs
+++ b/src/AElf.Kernel.CodeCheck/NewIrreversibleBlockFoundEventHandler.cs
@@ -6,8 +6,8 @@ using Volo.Abp.EventBus;
 
 namespace AElf.Kernel.CodeCheck
 {
-    public class NewIrreversibleBlockFoundEventHandler : ILocalEventHandler<NewIrreversibleBlockFoundEvent>,
-        ITransientDependency
+    public class NewIrreversibleBlockFoundEventHandler : ILocalEventHandler<NewIrreversibleBlockFoundEvent>
+        //, ITransientDependency // Not remove code hash list for now, hash list won't be so much.
     {
         private readonly ICheckedCodeHashProvider _checkedCodeHashProvider;
 

--- a/src/AElf.Kernel.CodeCheck/NewIrreversibleBlockFoundEventHandler.cs
+++ b/src/AElf.Kernel.CodeCheck/NewIrreversibleBlockFoundEventHandler.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using AElf.Kernel.Blockchain.Events;
+using AElf.Kernel.CodeCheck.Application;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.EventBus;
+
+namespace AElf.Kernel.CodeCheck
+{
+    public class NewIrreversibleBlockFoundEventHandler : ILocalEventHandler<NewIrreversibleBlockFoundEvent>,
+        ITransientDependency
+    {
+        private readonly ICheckedCodeHashProvider _checkedCodeHashProvider;
+
+        public NewIrreversibleBlockFoundEventHandler(ICheckedCodeHashProvider checkedCodeHashProvider)
+        {
+            _checkedCodeHashProvider = checkedCodeHashProvider;
+        }
+
+        public async Task HandleEventAsync(NewIrreversibleBlockFoundEvent eventData)
+        {
+            await _checkedCodeHashProvider.RemoveCodeHashAsync(new BlockIndex
+            {
+                BlockHash = eventData.BlockHash,
+                BlockHeight = eventData.BlockHeight
+            }, eventData.PreviousIrreversibleBlockHeight);
+        }
+    }
+}


### PR DESCRIPTION
By using CodeCheckValidationProvider.

If the blockchain syncing is stopped by CodeCheckValidationProvider, then this chain can only be recovered by restarting nodes in miners' sides then continue producing blocks from lib height.