### PR TITLE
[WIP] Tune mainchain dividend pool organization

### DIFF
--- a/contract/AElf.Contracts.Consensus.AEDPoS/AEDPoSContract_NextTerm.cs
+++ b/contract/AElf.Contracts.Consensus.AEDPoS/AEDPoSContract_NextTerm.cs
@@ -129,7 +129,8 @@ namespace AElf.Contracts.Consensus.AEDPoS
             }
 
             var miningRewardPerBlock = GetMiningRewardPerBlock();
-            var amount = previousRound.GetMinedBlocks().Mul(miningRewardPerBlock);
+            var minedBlocks = previousRound.GetMinedBlocks();
+            var amount = minedBlocks.Mul(miningRewardPerBlock);
             State.TreasuryContract.UpdateMiningReward.Send(new Int64Value {Value = miningRewardPerBlock});
 
             if (amount > 0)

--- a/contract/AElf.Contracts.Economic/EconomicContract.cs
+++ b/contract/AElf.Contracts.Economic/EconomicContract.cs
@@ -205,8 +205,9 @@ namespace AElf.Contracts.Economic
             State.ElectionContract.SetTreasurySchemeIds.Send(new SetTreasurySchemeIdsInput
             {
                 TreasuryHash = schemeIdsManagingByTreasuryContract[0],
-                VotesRewardHash = schemeIdsManagingByTreasuryContract[3],
-                ReElectionRewardHash = schemeIdsManagingByTreasuryContract[4],
+                BasicMinerHash = schemeIdsManagingByTreasuryContract[2],
+                WelcomeHash = schemeIdsManagingByTreasuryContract[3],
+                FlexibleHash = schemeIdsManagingByTreasuryContract[4],
                 SubsidyHash = schemeIdsManagingByElectionContract[0],
                 WelfareHash = schemeIdsManagingByElectionContract[1]
             });

--- a/contract/AElf.Contracts.Election/ElectionContractState.cs
+++ b/contract/AElf.Contracts.Election/ElectionContractState.cs
@@ -11,10 +11,11 @@ namespace AElf.Contracts.Election
         public BoolState VotingEventRegistered { get; set; }
 
         public SingletonState<Hash> TreasuryHash { get; set; }
+        public SingletonState<Hash> BasicMinerHash { get; set; }
         public SingletonState<Hash> WelfareHash { get; set; }
         public SingletonState<Hash> SubsidyHash { get; set; }
-        public SingletonState<Hash> VotesRewardHash { get; set; }
-        public SingletonState<Hash> ReElectionRewardHash { get; set; }
+        public SingletonState<Hash> FlexibleHash { get; set; }
+        public SingletonState<Hash> WelcomeHash { get; set; }
 
         public MappedState<string, ElectorVote> ElectorVotes { get; set; }
 

--- a/contract/AElf.Contracts.Election/ElectionContract_Candidate.cs
+++ b/contract/AElf.Contracts.Election/ElectionContract_Candidate.cs
@@ -179,7 +179,7 @@ namespace AElf.Contracts.Election
             if (dataCenterList.DataCenters.ContainsKey(pubkey))
             {
                 dataCenterList.DataCenters[pubkey] = 0;
-                IsUpdateDataCenterAfterMemberVoteAmountChange(dataCenterList, pubkey, true);
+                UpdateDataCenterAfterMemberVoteAmountChanged(dataCenterList, pubkey, true);
                 State.DataCentersRankingList.Value = dataCenterList;
             }
 

--- a/contract/AElf.Contracts.Profit/ProfitContract.cs
+++ b/contract/AElf.Contracts.Profit/ProfitContract.cs
@@ -137,7 +137,10 @@ namespace AElf.Contracts.Profit
             Assert(input.SchemeId != input.SubSchemeId, "Two schemes cannot be same.");
 
             var scheme = State.SchemeInfos[input.SchemeId];
-            Assert(scheme != null, "Scheme not found.");
+            if (scheme == null)
+            {
+                return new Empty();
+            }
 
             // ReSharper disable once PossibleNullReferenceException
             Assert(Context.Sender == scheme.Manager, "Only manager can remove sub-scheme.");

--- a/contract/AElf.Contracts.Profit/ProfitContract.cs
+++ b/contract/AElf.Contracts.Profit/ProfitContract.cs
@@ -670,18 +670,22 @@ namespace AElf.Contracts.Profit
         public override Empty ClaimProfits(ClaimProfitsInput input)
         {
             var scheme = State.SchemeInfos[input.SchemeId];
-            Assert(scheme != null, "Scheme not found.");
+            if (scheme == null)
+            {
+                throw new AssertionException("Scheme not found.");
+            }
             var beneficiary = input.Beneficiary ?? Context.Sender;
             var profitDetails = State.ProfitDetailsMap[input.SchemeId][beneficiary];
-            Assert(profitDetails != null, "Profit details not found.");
+            if (profitDetails == null)
+            {
+                throw new AssertionException("Profit details not found.");
+            }
 
             Context.LogDebug(
                 () => $"{Context.Sender} is trying to profit from {input.SchemeId.ToHex()} for {beneficiary}.");
 
-            // ReSharper disable once PossibleNullReferenceException
             var availableDetails = profitDetails.Details.Where(d =>
                 d.LastProfitPeriod == 0 ? d.EndPeriod >= d.StartPeriod : d.EndPeriod >= d.LastProfitPeriod).ToList();
-            // ReSharper disable once PossibleNullReferenceException
             var profitableDetails = availableDetails.Where(d => d.LastProfitPeriod < scheme.CurrentPeriod).ToList();
 
             Context.LogDebug(() =>
@@ -705,6 +709,24 @@ namespace AElf.Contracts.Profit
 
             State.ProfitDetailsMap[input.SchemeId][beneficiary] = new ProfitDetails {Details = {availableDetails}};
 
+            return new Empty();
+        }
+
+        public override Empty ClaimProfitsByPeriod(ClaimProfitsByPeriodInput input)
+        {
+            var scheme = State.SchemeInfos[input.SchemeId];
+            if (scheme == null)
+            {
+                throw new AssertionException("Scheme not found.");
+            }
+            var beneficiary = input.Beneficiary ?? Context.Sender;
+            var profitDetails = State.ProfitDetailsMap[input.SchemeId][beneficiary];
+            if (profitDetails == null)
+            {
+                throw new AssertionException("Profit details not found.");
+            }
+            
+            // TODO
             return new Empty();
         }
 

--- a/contract/AElf.Contracts.Profit/ViewMethods.cs
+++ b/contract/AElf.Contracts.Profit/ViewMethods.cs
@@ -36,7 +36,6 @@ namespace AElf.Contracts.Profit
 
         public override DistributedProfitsInfo GetDistributedProfitsInfo(SchemePeriod input)
         {
-            var virtualAddress = Context.ConvertVirtualAddressToContractAddress(input.SchemeId);
             var releasedProfitsVirtualAddress = GetDistributedPeriodProfitsVirtualAddress(input.SchemeId, input.Period);
             return State.DistributedProfitsMap[releasedProfitsVirtualAddress] ?? new DistributedProfitsInfo
             {

--- a/contract/AElf.Contracts.Treasury/TreasuryContract.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContract.cs
@@ -797,13 +797,13 @@ namespace AElf.Contracts.Treasury
             var oldWeightSetting = State.DividendPoolWeightSetting.Value ?? new DividendPoolWeightSetting();
             var parentSchemeId = State.TreasuryHash.Value;
             // Register or reset `MinerReward` to `Treasury`
-            SendToProfitContractToResetWeight(parentSchemeId, State.RewardHash.Value,
+            ResetWeight(parentSchemeId, State.RewardHash.Value,
                 oldWeightSetting.MinerRewardWeight, newWeightSetting.MinerRewardWeight);
             // Register or reset `BackupSubsidy` to `Treasury`
-            SendToProfitContractToResetWeight(parentSchemeId, State.SubsidyHash.Value,
+            ResetWeight(parentSchemeId, State.SubsidyHash.Value,
                 oldWeightSetting.BackupSubsidyWeight, newWeightSetting.BackupSubsidyWeight);
             // Register or reset `CitizenWelfare` to `Treasury`
-            SendToProfitContractToResetWeight(parentSchemeId, State.WelfareHash.Value,
+            ResetWeight(parentSchemeId, State.WelfareHash.Value,
                 oldWeightSetting.CitizenWelfareWeight, newWeightSetting.CitizenWelfareWeight);
         }
 
@@ -812,17 +812,17 @@ namespace AElf.Contracts.Treasury
             var oldWeightSetting = State.MinerRewardWeightSetting.Value ?? new MinerRewardWeightSetting();
             var parentSchemeId = State.RewardHash.Value;
             // Register or reset `MinerBasicReward` to `MinerReward`
-            SendToProfitContractToResetWeight(parentSchemeId, State.BasicRewardHash.Value,
+            ResetWeight(parentSchemeId, State.BasicRewardHash.Value,
                 oldWeightSetting.BasicMinerRewardWeight, newWeightSetting.BasicMinerRewardWeight);
             // Register or reset `WelcomeRewardWeight` to `MinerReward`
-            SendToProfitContractToResetWeight(parentSchemeId, State.WelcomeRewardHash.Value,
+            ResetWeight(parentSchemeId, State.WelcomeRewardHash.Value,
                 oldWeightSetting.WelcomeRewardWeight, newWeightSetting.WelcomeRewardWeight);
             // Register or reset `FlexibleRewardWeight` to `MinerReward`
-            SendToProfitContractToResetWeight(parentSchemeId, State.FlexibleRewardHash.Value,
+            ResetWeight(parentSchemeId, State.FlexibleRewardHash.Value,
                 oldWeightSetting.FlexibleRewardWeight, newWeightSetting.FlexibleRewardWeight);
         }
 
-        private void SendToProfitContractToResetWeight(Hash parentSchemeId, Hash subSchemeId, int oldWeight,
+        private void ResetWeight(Hash parentSchemeId, Hash subSchemeId, int oldWeight,
             int newWeight)
         {
             if (oldWeight == newWeight)

--- a/contract/AElf.Contracts.Treasury/TreasuryContract.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContract.cs
@@ -51,8 +51,8 @@ namespace AElf.Contracts.Treasury
             // `MinerBasicReward`, `MinerVotesWeightReward`, `ReElectedMinerReward`
             var profitItemNameList = new List<string>
             {
-                "Treasury", "MinerReward", "Subsidy", "Welfare", "Basic Reward", "Votes Weight Reward",
-                "Re-Election Reward"
+                "Treasury", "MinerReward", "Subsidy", "Welfare", "Basic Reward", "Flexible Reward",
+                "Welcome Reward"
             };
             for (var i = 0; i < 7; i++)
             {
@@ -63,7 +63,7 @@ namespace AElf.Contracts.Treasury
                     IsReleaseAllBalanceEveryTimeByDefault = true,
                     // Distribution of Citizen Welfare will delay one period.
                     DelayDistributePeriodCount = i == 3 ? 1 : 0,
-                    // Subsidy, Votes Weight Reward and Re-Election Reward can remove beneficiary directly (due to replaceable.)
+                    // Subsidy, Flexible Reward and Welcome Reward can remove beneficiary directly (due to replaceable.)
                     CanRemoveBeneficiaryDirectly = new List<int> {2, 5, 6}.Contains(i)
                 });
             }

--- a/contract/AElf.Contracts.Treasury/TreasuryContract.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContract.cs
@@ -381,13 +381,6 @@ namespace AElf.Contracts.Treasury
 
             State.ProfitContract.DistributeProfits.Send(new DistributeProfitsInput
             {
-                SchemeId = State.BasicRewardHash.Value,
-                Period = termNumber,
-                AmountsMap = {amountsMap}
-            });
-
-            State.ProfitContract.DistributeProfits.Send(new DistributeProfitsInput
-            {
                 SchemeId = State.WelcomeRewardHash.Value,
                 Period = termNumber,
                 AmountsMap = {amountsMap}
@@ -396,6 +389,13 @@ namespace AElf.Contracts.Treasury
             State.ProfitContract.DistributeProfits.Send(new DistributeProfitsInput
             {
                 SchemeId = State.FlexibleRewardHash.Value,
+                Period = termNumber,
+                AmountsMap = {amountsMap}
+            });
+
+            State.ProfitContract.DistributeProfits.Send(new DistributeProfitsInput
+            {
+                SchemeId = State.BasicRewardHash.Value,
                 Period = termNumber,
                 AmountsMap = {amountsMap}
             });

--- a/contract/AElf.Contracts.Treasury/TreasuryContract.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContract.cs
@@ -577,7 +577,7 @@ namespace AElf.Contracts.Treasury
             {
                 State.ProfitContract.AddSubScheme.Send(new AddSubSchemeInput
                 {
-                    SchemeId = State.WelcomeRewardHash.Value,
+                    SchemeId = State.FlexibleRewardHash.Value,
                     SubSchemeId = State.WelfareHash.Value,
                     SubSchemeShares = 1
                 });
@@ -586,7 +586,7 @@ namespace AElf.Contracts.Treasury
             {
                 State.ProfitContract.AddSubScheme.Send(new AddSubSchemeInput
                 {
-                    SchemeId = State.WelcomeRewardHash.Value,
+                    SchemeId = State.FlexibleRewardHash.Value,
                     SubSchemeId = State.BasicRewardHash.Value,
                     SubSchemeShares = 1
                 });
@@ -704,14 +704,14 @@ namespace AElf.Contracts.Treasury
                 },
                 WelcomeRewardProportionInfo = new SchemeProportionInfo
                 {
-                    SchemeId = State.FlexibleRewardHash.Value,
+                    SchemeId = State.WelcomeRewardHash.Value,
                     Proportion = weightSetting.WelcomeRewardWeight
                         .Mul(TreasuryContractConstants.OneHundredPercent).Div(weightSum)
                 }
             };
             weightProportion.FlexibleRewardProportionInfo = new SchemeProportionInfo
             {
-                SchemeId = State.WelcomeRewardHash.Value,
+                SchemeId = State.FlexibleRewardHash.Value,
                 Proportion = TreasuryContractConstants.OneHundredPercent
                     .Sub(weightProportion.BasicMinerRewardProportionInfo.Proportion)
                     .Sub(weightProportion.WelcomeRewardProportionInfo.Proportion)

--- a/contract/AElf.Contracts.Treasury/TreasuryContract.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContract.cs
@@ -496,16 +496,16 @@ namespace AElf.Contracts.Treasury
 
         private long CalculateShares(long producedBlocksCount, long averageProducedBlocksCount)
         {
-            if (producedBlocksCount < averageProducedBlocksCount.Div(5).Mul(4))
-            {
-                // If count < (4/5) * average_count, then ratio will be (count / average_count)
-                return producedBlocksCount.Div(averageProducedBlocksCount).Mul(producedBlocksCount);
-            }
-
             if (producedBlocksCount < averageProducedBlocksCount.Div(2))
             {
                 // If count < (1/2) * average_count, then this node won't share Basic Miner Reward.
                 return 0;
+            }
+
+            if (producedBlocksCount < averageProducedBlocksCount.Div(5).Mul(4))
+            {
+                // If count < (4/5) * average_count, then ratio will be (count / average_count)
+                return producedBlocksCount.Div(averageProducedBlocksCount).Mul(producedBlocksCount);
             }
 
             return producedBlocksCount;

--- a/contract/AElf.Contracts.Treasury/TreasuryContract.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContract.cs
@@ -32,8 +32,8 @@ namespace AElf.Contracts.Treasury
     ///
     /// 3 sub profit schemes for Mining Rewards:
     /// (Basic Rewards) - 4
-    /// (Miner's Votes Shares) - 1
-    /// (Re-Election Rewards) - 1
+    /// (Welcome Rewards) - 1
+    /// (Flexible Rewards) - 1
     ///
     /// 3 incomes:
     /// 1. 20% total supply of elf, from consensus contract
@@ -95,8 +95,8 @@ namespace AElf.Contracts.Treasury
             State.SubsidyHash.Value = managingSchemeIds[2];
             State.WelfareHash.Value = managingSchemeIds[3];
             State.BasicRewardHash.Value = managingSchemeIds[4];
-            State.VotesWeightRewardHash.Value = managingSchemeIds[5];
-            State.ReElectionRewardHash.Value = managingSchemeIds[6];
+            State.WelcomeRewardHash.Value = managingSchemeIds[5];
+            State.FlexibleRewardHash.Value = managingSchemeIds[6];
 
             var electionContractAddress =
                 Context.GetContractAddressByName(SmartContractConstants.ElectionContractSystemName);
@@ -140,9 +140,14 @@ namespace AElf.Contracts.Treasury
             {
                 Value = input.PeriodNumber
             });
-            UpdateTreasurySubItemsSharesBeforeDistribution(previousTermInformation);
+            
+            var victories = State.ElectionContract.GetVictories.Call(new Empty()).Value.Select(bs => bs.ToHex())
+                .ToList();
+            var newElectedMiners = victories.Where(p => State.LatestMinedTerm[p] == 0).ToList();
+
+            UpdateStateBeforeDistribution(previousTermInformation, newElectedMiners);
             ReleaseTreasurySubProfitItems(input.PeriodNumber);
-            UpdateTreasurySubItemsSharesAfterDistribution(previousTermInformation);
+            UpdateStateAfterDistribution(previousTermInformation, victories);
             return new Empty();
         }
 
@@ -318,8 +323,8 @@ namespace AElf.Contracts.Treasury
         {
             AssertPerformedByTreasuryController();
             Assert(
-                input.BasicMinerRewardWeight > 0 && input.ReElectionRewardWeight > 0 &&
-                input.VotesWeightRewardWeight > 0,
+                input.BasicMinerRewardWeight > 0 && input.WelcomeRewardWeight > 0 &&
+                input.FlexibleRewardWeight > 0,
                 "invalid input");
             ResetSubSchemeToMinerReward(input);
             State.MinerRewardWeightSetting.Value = input;
@@ -385,14 +390,14 @@ namespace AElf.Contracts.Treasury
 
             State.ProfitContract.DistributeProfits.Send(new DistributeProfitsInput
             {
-                SchemeId = State.VotesWeightRewardHash.Value,
+                SchemeId = State.WelcomeRewardHash.Value,
                 Period = termNumber,
                 AmountsMap = {amountsMap}
             });
 
             State.ProfitContract.DistributeProfits.Send(new DistributeProfitsInput
             {
-                SchemeId = State.ReElectionRewardHash.Value,
+                SchemeId = State.FlexibleRewardHash.Value,
                 Period = termNumber,
                 AmountsMap = {amountsMap}
             });
@@ -416,7 +421,7 @@ namespace AElf.Contracts.Treasury
             }
         }
 
-        private void UpdateTreasurySubItemsSharesBeforeDistribution(Round previousTermInformation)
+        private void UpdateStateBeforeDistribution(Round previousTermInformation, List<string> newElectedMiners)
         {
             var previousPreviousTermInformation = State.AEDPoSContract.GetPreviousTermInformation.Call(new Int64Value
             {
@@ -424,15 +429,16 @@ namespace AElf.Contracts.Treasury
             });
 
             UpdateBasicMinerRewardWeights(new List<Round> {previousPreviousTermInformation, previousTermInformation});
+            UpdateWelcomeRewardWeights(previousTermInformation, newElectedMiners);
+            UpdateFlexibleRewardWeights(newElectedMiners);
         }
 
-        private void UpdateTreasurySubItemsSharesAfterDistribution(Round previousTermInformation)
+        private void UpdateStateAfterDistribution(Round previousTermInformation, List<string> victories)
         {
-            var victories = State.ElectionContract.GetVictories.Call(new Empty()).Value.Select(bs => bs.ToHex())
-                .ToList();
-
-            UpdateReElectionRewardWeights(previousTermInformation, victories);
-            UpdateVotesWeightRewardWeights(previousTermInformation, victories);
+            foreach (var victory in victories)
+            {
+                State.LatestMinedTerm[victory] = previousTermInformation.TermNumber;
+            }
         }
 
         /// <summary>
@@ -472,136 +478,85 @@ namespace AElf.Contracts.Treasury
             });
         }
 
-        /// <summary>
-        /// Remove current total shares of Re-Election Reward,
-        /// Add shares to re-elected miners based on their continual appointment count.
-        /// </summary>
-        /// <param name="previousTermInformation"></param>
-        /// <param name="victories"></param>
-        private void UpdateReElectionRewardWeights(Round previousTermInformation, ICollection<string> victories)
+        private void UpdateWelcomeRewardWeights(Round previousTermInformation, List<string> newElectedMiners)
         {
             var previousMinerAddresses = previousTermInformation.RealTimeMinersInformation.Keys
                 .Select(k => Address.FromPublicKey(ByteArrayHelper.HexStringToByteArray(k))).ToList();
-            var reElectionRewardProfitSubBeneficiaries = new RemoveBeneficiariesInput
+            var possibleWelcomeBeneficiaries = new RemoveBeneficiariesInput
             {
-                SchemeId = State.ReElectionRewardHash.Value,
-                Beneficiaries = {previousMinerAddresses}
+                SchemeId = State.WelcomeRewardHash.Value,
+                Beneficiaries = { previousMinerAddresses }
             };
-            State.ProfitContract.RemoveBeneficiaries.Send(reElectionRewardProfitSubBeneficiaries);
-
-            var minerReElectionInformation = State.MinerReElectionInformation.Value ??
-                                             InitialMinerReElectionInformation(previousTermInformation
-                                                 .RealTimeMinersInformation.Keys);
-
-            AddBeneficiariesForReElectionScheme(previousTermInformation.TermNumber.Add(1), victories,
-                minerReElectionInformation);
-
-            var recordedMiners = minerReElectionInformation.Clone().ContinualAppointmentTimes.Keys;
-            foreach (var miner in recordedMiners)
+            State.ProfitContract.RemoveBeneficiaries.Send(possibleWelcomeBeneficiaries);
+            State.ProfitContract.RemoveSubScheme.Send(new RemoveSubSchemeInput
             {
-                if (!victories.Contains(miner))
+                SchemeId = State.WelcomeRewardHash.Value,
+                SubSchemeId = State.BasicRewardHash.Value
+            });
+
+            if (newElectedMiners.Any())
+            {
+                var newBeneficiaries = new AddBeneficiariesInput
                 {
-                    minerReElectionInformation.ContinualAppointmentTimes.Remove(miner);
-                }
-            }
-
-            State.MinerReElectionInformation.Value = minerReElectionInformation;
-        }
-
-        private void AddBeneficiariesForReElectionScheme(long endPeriod, IEnumerable<string> victories,
-            MinerReElectionInformation minerReElectionInformation)
-        {
-            var reElectionProfitAddBeneficiaries = new AddBeneficiariesInput
-            {
-                SchemeId = State.ReElectionRewardHash.Value,
-                EndPeriod = endPeriod
-            };
-
-            foreach (var victory in victories)
-            {
-                if (minerReElectionInformation.ContinualAppointmentTimes.ContainsKey(victory))
+                    SchemeId = State.WelcomeRewardHash.Value,
+                    EndPeriod = previousTermInformation.TermNumber.Add(1)
+                };
+                foreach (var minerAddress in newElectedMiners.Select(miner =>
+                    Address.FromPublicKey(ByteArrayHelper.HexStringToByteArray(miner))))
                 {
-                    var minerAddress = Address.FromPublicKey(ByteArrayHelper.HexStringToByteArray(victory));
-                    var continualAppointmentCount =
-                        minerReElectionInformation.ContinualAppointmentTimes[victory].Add(1);
-                    minerReElectionInformation.ContinualAppointmentTimes[victory] = continualAppointmentCount;
-                    reElectionProfitAddBeneficiaries.BeneficiaryShares.Add(new BeneficiaryShare
+                    newBeneficiaries.BeneficiaryShares.Add(new BeneficiaryShare
                     {
                         Beneficiary = minerAddress,
-                        Shares = Math.Min(continualAppointmentCount,
-                            TreasuryContractConstants.MaximumReElectionRewardShare)
+                        Shares = 1
                     });
                 }
-                else
+
+                if (newBeneficiaries.BeneficiaryShares.Any())
                 {
-                    minerReElectionInformation.ContinualAppointmentTimes.Add(victory, 0);
+                    State.ProfitContract.AddBeneficiaries.Send(newBeneficiaries);
                 }
             }
-
-            if (reElectionProfitAddBeneficiaries.BeneficiaryShares.Any())
+            else
             {
-                State.ProfitContract.AddBeneficiaries.Send(reElectionProfitAddBeneficiaries);
+                State.ProfitContract.AddSubScheme.Send(new AddSubSchemeInput
+                {
+                    SchemeId = State.WelcomeRewardHash.Value,
+                    SubSchemeId = State.BasicRewardHash.Value,
+                    SubSchemeShares = 1
+                });
             }
         }
-
-        private MinerReElectionInformation InitialMinerReElectionInformation(ICollection<string> previousMiners)
+        
+        private void UpdateFlexibleRewardWeights(List<string> newElectedMiners)
         {
-            var information = new MinerReElectionInformation();
-            foreach (var previousMiner in previousMiners)
+            State.ProfitContract.RemoveSubScheme.Send(new RemoveSubSchemeInput
             {
-                information.ContinualAppointmentTimes.Add(previousMiner, 0);
-            }
-
-            return information;
-        }
-
-        /// <summary>
-        /// Remove current total shares of Votes Weight Reward,
-        /// Add shares to current miners based on votes they obtained.
-        /// </summary>
-        /// <param name="previousTermInformation"></param>
-        /// <param name="victories"></param>
-        private void UpdateVotesWeightRewardWeights(Round previousTermInformation, IEnumerable<string> victories)
-        {
-            var previousMinerAddresses = previousTermInformation.RealTimeMinersInformation.Keys
-                .Select(k => Address.FromPublicKey(ByteArrayHelper.HexStringToByteArray(k))).ToList();
-            var votesWeightRewardProfitSubBeneficiaries = new RemoveBeneficiariesInput
+                SchemeId = State.FlexibleRewardHash.Value,
+                SubSchemeId = State.WelfareHash.Value
+            });
+            State.ProfitContract.RemoveSubScheme.Send(new RemoveSubSchemeInput
             {
-                SchemeId = State.VotesWeightRewardHash.Value,
-                Beneficiaries = {previousMinerAddresses}
-            };
-            State.ProfitContract.RemoveBeneficiaries.Send(votesWeightRewardProfitSubBeneficiaries);
+                SchemeId = State.FlexibleRewardHash.Value,
+                SubSchemeId = State.BasicRewardHash.Value
+            });
 
-            var votesWeightRewardProfitAddBeneficiaries = new AddBeneficiariesInput
+            if (newElectedMiners.Any())
             {
-                SchemeId = State.VotesWeightRewardHash.Value,
-                EndPeriod = previousTermInformation.TermNumber.Add(1)
-            };
-
-            var dataCenterRankingList = State.ElectionContract.GetDataCenterRankingList.Call(new Empty());
-
-            foreach (var victory in victories)
-            {
-                var obtainedVotes = 0L;
-                if (dataCenterRankingList.DataCenters.ContainsKey(victory))
+                State.ProfitContract.AddSubScheme.Send(new AddSubSchemeInput
                 {
-                    obtainedVotes = dataCenterRankingList.DataCenters[victory];
-                }
-
-                var minerAddress = Address.FromPublicKey(ByteArrayHelper.HexStringToByteArray(victory));
-                if (obtainedVotes > 0)
-                {
-                    votesWeightRewardProfitAddBeneficiaries.BeneficiaryShares.Add(new BeneficiaryShare
-                    {
-                        Beneficiary = minerAddress,
-                        Shares = obtainedVotes
-                    });
-                }
+                    SchemeId = State.WelcomeRewardHash.Value,
+                    SubSchemeId = State.WelfareHash.Value,
+                    SubSchemeShares = 1
+                });
             }
-
-            if (votesWeightRewardProfitAddBeneficiaries.BeneficiaryShares.Any())
+            else
             {
-                State.ProfitContract.AddBeneficiaries.Send(votesWeightRewardProfitAddBeneficiaries);
+                State.ProfitContract.AddSubScheme.Send(new AddSubSchemeInput
+                {
+                    SchemeId = State.WelcomeRewardHash.Value,
+                    SubSchemeId = State.BasicRewardHash.Value,
+                    SubSchemeShares = 1
+                });
             }
         }
 
@@ -704,8 +659,8 @@ namespace AElf.Contracts.Treasury
         public override MinerRewardWeightProportion GetMinerRewardWeightProportion(Empty input)
         {
             var weightSetting = State.MinerRewardWeightSetting.Value ?? GetDefaultMinerRewardWeightSetting();
-            var weightSum = weightSetting.BasicMinerRewardWeight.Add(weightSetting.ReElectionRewardWeight)
-                .Add(weightSetting.VotesWeightRewardWeight);
+            var weightSum = weightSetting.BasicMinerRewardWeight.Add(weightSetting.WelcomeRewardWeight)
+                .Add(weightSetting.FlexibleRewardWeight);
             var weightProportion = new MinerRewardWeightProportion
             {
                 BasicMinerRewardProportionInfo = new SchemeProportionInfo
@@ -714,19 +669,19 @@ namespace AElf.Contracts.Treasury
                     Proportion = weightSetting.BasicMinerRewardWeight
                         .Mul(TreasuryContractConstants.OneHundredPercent).Div(weightSum)
                 },
-                ReElectionRewardProportionInfo = new SchemeProportionInfo
+                WelcomeRewardProportionInfo = new SchemeProportionInfo
                 {
-                    SchemeId = State.ReElectionRewardHash.Value,
-                    Proportion = weightSetting.ReElectionRewardWeight
+                    SchemeId = State.FlexibleRewardHash.Value,
+                    Proportion = weightSetting.WelcomeRewardWeight
                         .Mul(TreasuryContractConstants.OneHundredPercent).Div(weightSum)
                 }
             };
-            weightProportion.VotesWeightRewardProportionInfo = new SchemeProportionInfo
+            weightProportion.FlexibleRewardProportionInfo = new SchemeProportionInfo
             {
-                SchemeId = State.VotesWeightRewardHash.Value,
+                SchemeId = State.WelcomeRewardHash.Value,
                 Proportion = TreasuryContractConstants.OneHundredPercent
                     .Sub(weightProportion.BasicMinerRewardProportionInfo.Proportion)
-                    .Sub(weightProportion.ReElectionRewardProportionInfo.Proportion)
+                    .Sub(weightProportion.WelcomeRewardProportionInfo.Proportion)
             };
             return weightProportion;
         }
@@ -787,8 +742,8 @@ namespace AElf.Contracts.Treasury
             return new MinerRewardWeightSetting
             {
                 BasicMinerRewardWeight = 2,
-                VotesWeightRewardWeight = 1,
-                ReElectionRewardWeight = 1
+                WelcomeRewardWeight = 1,
+                FlexibleRewardWeight = 1
             };
         }
 
@@ -814,12 +769,12 @@ namespace AElf.Contracts.Treasury
             // Register or reset `MinerBasicReward` to `MinerReward`
             SendToProfitContractToResetWeight(parentSchemeId, State.BasicRewardHash.Value,
                 oldWeightSetting.BasicMinerRewardWeight, newWeightSetting.BasicMinerRewardWeight);
-            // Register or reset `MinerVotesWeightReward` to `MinerReward`
-            SendToProfitContractToResetWeight(parentSchemeId, State.VotesWeightRewardHash.Value,
-                oldWeightSetting.VotesWeightRewardWeight, newWeightSetting.VotesWeightRewardWeight);
-            // Register or reset `ReElectionMinerReward` to `MinerReward`
-            SendToProfitContractToResetWeight(parentSchemeId, State.ReElectionRewardHash.Value,
-                oldWeightSetting.ReElectionRewardWeight, newWeightSetting.ReElectionRewardWeight);
+            // Register or reset `WelcomeRewardWeight` to `MinerReward`
+            SendToProfitContractToResetWeight(parentSchemeId, State.WelcomeRewardHash.Value,
+                oldWeightSetting.WelcomeRewardWeight, newWeightSetting.WelcomeRewardWeight);
+            // Register or reset `FlexibleRewardWeight` to `MinerReward`
+            SendToProfitContractToResetWeight(parentSchemeId, State.FlexibleRewardHash.Value,
+                oldWeightSetting.FlexibleRewardWeight, newWeightSetting.FlexibleRewardWeight);
         }
 
         private void SendToProfitContractToResetWeight(Hash parentSchemeId, Hash subSchemeId, int oldWeight,
@@ -884,8 +839,6 @@ namespace AElf.Contracts.Treasury
             Assert(
                 Context.GetContractAddressByName(SmartContractConstants.ConsensusContractSystemName) == Context.Sender,
                 "Only AEDPoS Contract can record miner replacement.");
-            Context.LogDebug(() =>
-                $"Updating re-election and votes-weight rewords info: {input.OldPubkey} -> {input.NewPubkey}");
 
             if (State.ProfitContract.Value == null)
             {
@@ -893,74 +846,9 @@ namespace AElf.Contracts.Treasury
                     Context.GetContractAddressByName(SmartContractConstants.ProfitContractSystemName);
             }
 
-            // Update own re-election state.
-            var reElectionInformation = State.MinerReElectionInformation.Value;
-            if (reElectionInformation == null ||
-                !reElectionInformation.ContinualAppointmentTimes.ContainsKey(input.OldPubkey)) return new Empty();
-            var oldTimes = reElectionInformation.ContinualAppointmentTimes[input.OldPubkey];
-            reElectionInformation.ContinualAppointmentTimes.Remove(input.OldPubkey);
-            reElectionInformation.ContinualAppointmentTimes.Add(input.NewPubkey, oldTimes);
-            State.MinerReElectionInformation.Value = reElectionInformation;
-
-            // Update re-election profit scheme beneficiary.
-            var oldAddress = Address.FromPublicKey(ByteArrayHelper.HexStringToByteArray(input.OldPubkey));
-            var newAddress = Address.FromPublicKey(ByteArrayHelper.HexStringToByteArray(input.NewPubkey));
-            var reElectionDetail = State.ProfitContract.GetProfitDetails.Call(new GetProfitDetailsInput
-            {
-                SchemeId = State.ReElectionRewardHash.Value,
-                Beneficiary = oldAddress
-            }).Details.LastOrDefault();
-            if (reElectionDetail != null && reElectionDetail.EndPeriod >= input.CurrentTermNumber)
-            {
-                State.ProfitContract.RemoveBeneficiary.Send(new RemoveBeneficiaryInput
-                {
-                    SchemeId = State.ReElectionRewardHash.Value,
-                    Beneficiary = oldAddress
-                });
-                State.ProfitContract.AddBeneficiary.Send(new AddBeneficiaryInput
-                {
-                    SchemeId = State.ReElectionRewardHash.Value,
-                    BeneficiaryShare = new BeneficiaryShare
-                    {
-                        Beneficiary = newAddress,
-                        Shares = reElectionDetail.Shares,
-                    },
-                    EndPeriod = input.CurrentTermNumber
-                });
-            }
-            else
-            {
-                Context.LogDebug(() => $"Re-election profit scheme details of {input.OldPubkey} is null.");
-            }
-
-            // Update votes-weight profit scheme beneficiary.
-            var votesWeightDetail = State.ProfitContract.GetProfitDetails.Call(new GetProfitDetailsInput
-            {
-                SchemeId = State.VotesWeightRewardHash.Value,
-                Beneficiary = oldAddress
-            }).Details.LastOrDefault();
-            if (votesWeightDetail != null && votesWeightDetail.EndPeriod >= input.CurrentTermNumber)
-            {
-                State.ProfitContract.RemoveBeneficiary.Send(new RemoveBeneficiaryInput
-                {
-                    SchemeId = State.VotesWeightRewardHash.Value,
-                    Beneficiary = oldAddress
-                });
-                State.ProfitContract.AddBeneficiary.Send(new AddBeneficiaryInput
-                {
-                    SchemeId = State.VotesWeightRewardHash.Value,
-                    BeneficiaryShare = new BeneficiaryShare
-                    {
-                        Beneficiary = newAddress,
-                        Shares = votesWeightDetail.Shares
-                    },
-                    EndPeriod = input.CurrentTermNumber
-                });
-            }
-            else
-            {
-                Context.LogDebug(() => $"Votes-weight profit scheme details of {input.OldPubkey} is null.");
-            }
+            var latestMinedTerm = State.LatestMinedTerm[input.OldPubkey];
+            State.LatestMinedTerm[input.NewPubkey] = latestMinedTerm;
+            State.LatestMinedTerm.Remove(input.OldPubkey);
 
             return new Empty();
         }

--- a/contract/AElf.Contracts.Treasury/TreasuryContract.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContract.cs
@@ -505,7 +505,7 @@ namespace AElf.Contracts.Treasury
             if (producedBlocksCount < averageProducedBlocksCount.Div(5).Mul(4))
             {
                 // If count < (4/5) * average_count, then ratio will be (count / average_count)
-                return producedBlocksCount.Div(averageProducedBlocksCount).Mul(producedBlocksCount);
+                return producedBlocksCount.Mul(producedBlocksCount).Div(averageProducedBlocksCount);
             }
 
             return producedBlocksCount;

--- a/contract/AElf.Contracts.Treasury/TreasuryContractState.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContractState.cs
@@ -18,10 +18,8 @@ namespace AElf.Contracts.Treasury
         public SingletonState<Hash> RewardHash { get; set; }
 
         public SingletonState<Hash> BasicRewardHash { get; set; }
-        public SingletonState<Hash> VotesWeightRewardHash { get; set; }
-        public SingletonState<Hash> ReElectionRewardHash { get; set; }
-
-        public SingletonState<MinerReElectionInformation> MinerReElectionInformation { get; set; }
+        public SingletonState<Hash> WelcomeRewardHash { get; set; }
+        public SingletonState<Hash> FlexibleRewardHash { get; set; }
 
         public MappedState<string, MethodFees> TransactionFees { get; set; }
 
@@ -35,5 +33,10 @@ namespace AElf.Contracts.Treasury
         public MappedState<long, Dividends> DonatedDividends { get; set; }
 
         public SingletonState<long> MiningReward { get; set; }
+
+        /// <summary>
+        /// Pubkey -> Latest Mined Term Number.
+        /// </summary>
+        public MappedState<string, long> LatestMinedTerm { get; set; }
     }
 }

--- a/contract/AElf.Contracts.Treasury/TreasuryContractState.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContractState.cs
@@ -38,5 +38,7 @@ namespace AElf.Contracts.Treasury
         /// Pubkey -> Latest Mined Term Number.
         /// </summary>
         public MappedState<string, long> LatestMinedTerm { get; set; }
+
+        public MappedState<string, bool> IsReplacedEvilMiner { get; set; }
     }
 }

--- a/contract/AElf.Contracts.Treasury/TreasuryContractState.cs
+++ b/contract/AElf.Contracts.Treasury/TreasuryContractState.cs
@@ -40,5 +40,7 @@ namespace AElf.Contracts.Treasury
         public MappedState<string, long> LatestMinedTerm { get; set; }
 
         public MappedState<string, bool> IsReplacedEvilMiner { get; set; }
+
+        public MappedState<long, bool> HasNewMiner { get; set; }
     }
 }

--- a/protobuf/election_contract.proto
+++ b/protobuf/election_contract.proto
@@ -428,7 +428,7 @@ message SetTreasurySchemeIdsInput {
     aelf.Hash subsidy_hash = 3;
     // The scheme id of votes reward.
     aelf.Hash votes_reward_hash = 4;
-    // The scheme id of re-election reward.
+    // The scheme id of Welcome reward.
     aelf.Hash re_election_reward_hash = 5;
 }
 

--- a/protobuf/election_contract.proto
+++ b/protobuf/election_contract.proto
@@ -426,10 +426,12 @@ message SetTreasurySchemeIdsInput {
     aelf.Hash welfare_hash = 2;
     // The scheme id of subsidy reward.
     aelf.Hash subsidy_hash = 3;
-    // The scheme id of votes reward.
-    aelf.Hash votes_reward_hash = 4;
-    // The scheme id of Welcome reward.
-    aelf.Hash re_election_reward_hash = 5;
+    // The scheme id of welcome reward.
+    aelf.Hash welcome_hash = 4;
+    // The scheme id of flexible reward.
+    aelf.Hash flexible_hash = 5;
+    // The scheme id of basic miner reward.
+    aelf.Hash basic_miner_hash = 6;
 }
 
 message DataCenterRankingList {

--- a/protobuf/profit_contract.proto
+++ b/protobuf/profit_contract.proto
@@ -42,7 +42,10 @@ service ProfitContract {
     // The beneficiary draws tokens from the scheme.
     rpc ClaimProfits (ClaimProfitsInput) returns (google.protobuf.Empty) {
     }
-    
+
+    rpc ClaimProfitsByPeriod (ClaimProfitsByPeriodInput) returns (google.protobuf.Empty) {
+    }
+
     // Distribute profits to schemes, including its sub scheme according to period and  token symbol, 
     // should be called by the manager. 
     rpc DistributeProfits (DistributeProfitsInput) returns (google.protobuf.Empty) {
@@ -190,6 +193,15 @@ message ClaimProfitsInput {
     aelf.Hash scheme_id = 1;
     // The address of beneficiary.
     aelf.Address beneficiary = 2;
+}
+
+message ClaimProfitsByPeriodInput {
+    // The scheme id.
+    aelf.Hash scheme_id = 1;
+    // The address of beneficiary.
+    aelf.Address beneficiary = 2;
+    // Target period number.
+    int64 period = 3;
 }
 
 message DistributeProfitsInput {

--- a/protobuf/treasury_contract.proto
+++ b/protobuf/treasury_contract.proto
@@ -95,21 +95,21 @@ message MinerReElectionInformation {
 }
 
 message DividendPoolWeightSetting {
-    // The dividend weight of citizen welfare.
+    // The dividend weight for citizen.
     int32 citizen_welfare_weight = 1;
-    // The dividend weight of candidate nodes.
+    // The dividend weight for backup nodes.
     int32 backup_subsidy_weight = 2;
-    // The dividend weight of miner.
+    // The dividend weight for miners.
     int32 miner_reward_weight = 3;
 }
 
 message MinerRewardWeightSetting {
-    // The dividend weight of the basic income of the miner.
+    // The dividend weight for all current miners.
     int32 basic_miner_reward_weight = 1;
-    // The dividend weight of the vote of the miner.
-    int32 votes_weight_reward_weight = 2;
-    // The dividend weight of the reappointment of the miner.
-    int32 re_election_reward_weight = 3;
+    // The dividend weight for new miners.
+    int32 welcome_reward_weight = 2;
+    // The dividend weight for the flexible scheme.
+    int32 flexible_reward_weight = 3;
 }
 
 message SchemeProportionInfo {
@@ -132,9 +132,9 @@ message MinerRewardWeightProportion {
     // The proportion of the basic income of the miner.
     SchemeProportionInfo basic_miner_reward_proportion_info = 1;
     // The proportion of the vote of the miner.
-    SchemeProportionInfo votes_weight_reward_proportion_info = 2;
+    SchemeProportionInfo welcome_reward_proportion_info = 2;
     // The proportion of the reappointment of the miner.
-    SchemeProportionInfo re_election_reward_proportion_info = 3;
+    SchemeProportionInfo flexible_reward_proportion_info = 3;
 }
 
 message RecordMinerReplacementInput {

--- a/test/AElf.Contracts.Economic.AEDPoSExtension.Tests/EconomicTestHelpers.cs
+++ b/test/AElf.Contracts.Economic.AEDPoSExtension.Tests/EconomicTestHelpers.cs
@@ -57,9 +57,9 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
                 await ProfitStub.GetScheme.CallAsync(treasuryScheme.SubSchemes[2].SchemeId));
             schemes.Add(SchemeType.MinerBasicReward,
                 await ProfitStub.GetScheme.CallAsync(minerRewardScheme.SubSchemes[0].SchemeId));
-            schemes.Add(SchemeType.VotesWeightReward,
+            schemes.Add(SchemeType.WelcomeReward,
                 await ProfitStub.GetScheme.CallAsync(minerRewardScheme.SubSchemes[1].SchemeId));
-            schemes.Add(SchemeType.ReElectionReward,
+            schemes.Add(SchemeType.FlexibleReward,
                 await ProfitStub.GetScheme.CallAsync(minerRewardScheme.SubSchemes[2].SchemeId));
             return schemes;
         }
@@ -103,8 +103,8 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
             CitizenWelfare,
 
             MinerBasicReward,
-            VotesWeightReward,
-            ReElectionReward
+            WelcomeReward,
+            FlexibleReward
         }
 
         internal List<AEDPoSContractImplContainer.AEDPoSContractImplStub> ConvertKeyPairsToConsensusStubs(

--- a/test/AElf.Contracts.Economic.AEDPoSExtension.Tests/TreasuryDistributionTests.cs
+++ b/test/AElf.Contracts.Economic.AEDPoSExtension.Tests/TreasuryDistributionTests.cs
@@ -6,6 +6,7 @@ using AElf.Contracts.Election;
 using AElf.Contracts.Profit;
 using AElf.ContractTestKit;
 using AElf.ContractTestKit.AEDPoSExtension;
+using AElf.CSharp.Core;
 using AElf.TestBase;
 using AElf.Types;
 using Google.Protobuf.WellKnownTypes;
@@ -105,28 +106,28 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
                     amount.ShouldBe(distributedAmount / 20);
                 }
 
-                // Citizen Welfare: -75% (Burned)
+                // Citizen Welfare: -75% (Burned) + (-5%) (from Flexible Reward)
                 {
                     var distributedInformation =
                         await GetDistributedInformationAsync(_schemes[SchemeType.CitizenWelfare].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
-                    amount.ShouldBe(-distributedAmount * 3 / 4);
+                    amount.ShouldBe(-distributedAmount * 4 / 5);
                 }
 
-                // Votes Weight Reward: -5% (Burned)
+                // Flexible Reward: 5%
                 {
                     var distributedInformation =
-                        await GetDistributedInformationAsync(_schemes[SchemeType.VotesWeightReward].SchemeId, period);
+                        await GetDistributedInformationAsync(_schemes[SchemeType.WelcomeReward].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
-                    amount.ShouldBe(-distributedAmount / 20);
+                    amount.ShouldBe(distributedAmount / 20);
                 }
 
-                // Re-Election Reward: -5% (Burned)
+                // Welcome Reward: 5%
                 {
                     var distributedInformation =
-                        await GetDistributedInformationAsync(_schemes[SchemeType.ReElectionReward].SchemeId, period);
+                        await GetDistributedInformationAsync(_schemes[SchemeType.FlexibleReward].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
-                    amount.ShouldBe(-distributedAmount / 20);
+                    amount.ShouldBe(distributedAmount / 20);
                 }
                 return distributedAmount;
             }
@@ -224,12 +225,12 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
                     };
                 }
 
-                // Citizen Welfare: 75%
+                // Citizen Welfare: 75% + 5% (from Flexible Reward)
                 {
                     var distributedInformation =
                         await GetDistributedInformationAsync(_schemes[SchemeType.CitizenWelfare].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
-                    amount.ShouldBe(distributedAmount * 3 / 4);
+                    amount.ShouldBe(distributedAmount * 4 / 5);
                     var totalShares = distributedInformation.TotalShares;
                     totalShares.ShouldBePositive();
 
@@ -240,32 +241,33 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
                     };
                 }
 
-                // Votes Weight Reward: 5%
+                // Welcome Reward: 5%
                 {
                     var distributedInformation =
-                        await GetDistributedInformationAsync(_schemes[SchemeType.VotesWeightReward].SchemeId, period);
+                        await GetDistributedInformationAsync(_schemes[SchemeType.WelcomeReward].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
                     amount.ShouldBe(distributedAmount / 20);
                     var totalShares = distributedInformation.TotalShares;
-                    totalShares.ShouldBe(7000);
+                    // Went to miners. Now there are 10 miners.
+                    totalShares.ShouldBe(10);
 
-                    information[SchemeType.VotesWeightReward] = new DistributionInformation
+                    information[SchemeType.WelcomeReward] = new DistributionInformation
                     {
                         Amount = amount,
                         TotalShares = totalShares
                     };
                 }
 
-                // Re-Election Reward: 5%
+                // Flexible Reward: 5%
                 {
                     var distributedInformation =
-                        await GetDistributedInformationAsync(_schemes[SchemeType.ReElectionReward].SchemeId, period);
+                        await GetDistributedInformationAsync(_schemes[SchemeType.FlexibleReward].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
                     amount.ShouldBe(distributedAmount / 20);
                     var totalShares = distributedInformation.TotalShares;
-                    totalShares.ShouldBe(5);
+                    totalShares.ShouldBe(1);
 
-                    information[SchemeType.ReElectionReward] = new DistributionInformation
+                    information[SchemeType.FlexibleReward] = new DistributionInformation
                     {
                         Amount = amount,
                         TotalShares = totalShares
@@ -352,8 +354,11 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
                     var totalShares = distributedInformation.TotalShares;
                     var previousTermInformation =
                         ConsensusStub.GetPreviousTermInformation.CallAsync(new Int64Value {Value = 3}).Result;
-                    totalShares.ShouldBe(
-                        previousTermInformation.RealTimeMinersInformation.Values.Sum(i => i.ProducedBlocks));
+                    var producedBlocks = previousTermInformation.RealTimeMinersInformation.Values
+                        .Select(i => i.ProducedBlocks).ToList();
+                    var average = CalculateAverage(producedBlocks);
+                    var shares = producedBlocks.Select(i => CalculateShares(i, average)).ToList();
+                    totalShares.ShouldBe(shares.Sum());
 
                     information[SchemeType.MinerBasicReward] = new DistributionInformation
                     {
@@ -378,12 +383,12 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
                     };
                 }
 
-                // Citizen Welfare: 75%
+                // Citizen Welfare: 75% + 5% (from Flexible Reward)
                 {
                     var distributedInformation =
                         await GetDistributedInformationAsync(_schemes[SchemeType.CitizenWelfare].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
-                    amount.ShouldBe(distributedAmount * 3 / 4);
+                    amount.ShouldBe(distributedAmount * 4 / 5);
                     var totalShares = distributedInformation.TotalShares;
                     totalShares.ShouldBePositive();
 
@@ -394,32 +399,33 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
                     };
                 }
 
-                // Votes Weight Reward: 5%
+                // Welcome Reward: 5%
                 {
                     var distributedInformation =
-                        await GetDistributedInformationAsync(_schemes[SchemeType.VotesWeightReward].SchemeId, period);
+                        await GetDistributedInformationAsync(_schemes[SchemeType.WelcomeReward].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
                     amount.ShouldBe(distributedAmount / 20);
                     var totalShares = distributedInformation.TotalShares;
-                    totalShares.ShouldBe(7000 + 17000);
+                    // Went to 2 new miners -> Welcome
+                    totalShares.ShouldBe(2);
 
-                    information[SchemeType.VotesWeightReward] = new DistributionInformation
+                    information[SchemeType.WelcomeReward] = new DistributionInformation
                     {
                         Amount = amount,
                         TotalShares = totalShares
                     };
                 }
 
-                // Re-Election Reward: 5%
+                // Flexible Reward: 5%
                 {
                     var distributedInformation =
-                        await GetDistributedInformationAsync(_schemes[SchemeType.ReElectionReward].SchemeId, period);
+                        await GetDistributedInformationAsync(_schemes[SchemeType.FlexibleReward].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
                     amount.ShouldBe(distributedAmount / 20);
                     var totalShares = distributedInformation.TotalShares;
-                    totalShares.ShouldBe(11);
+                    totalShares.ShouldBe(1);
 
-                    information[SchemeType.ReElectionReward] = new DistributionInformation
+                    information[SchemeType.FlexibleReward] = new DistributionInformation
                     {
                         Amount = amount,
                         TotalShares = totalShares
@@ -428,6 +434,34 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
             }
 
             return information;
+        }
+        
+        /// <summary>
+        /// Just to make sure not using double type.
+        /// </summary>
+        /// <param name="list"></param>
+        /// <returns></returns>
+        private long CalculateAverage(List<long> list)
+        {
+            var sum = list.Sum();
+            return sum.Div(list.Count);
+        }
+
+        private long CalculateShares(long producedBlocksCount, long averageProducedBlocksCount)
+        {
+            if (producedBlocksCount < averageProducedBlocksCount.Div(2))
+            {
+                // If count < (1/2) * average_count, then this node won't share Basic Miner Reward.
+                return 0;
+            }
+
+            if (producedBlocksCount < averageProducedBlocksCount.Div(5).Mul(4))
+            {
+                // If count < (4/5) * average_count, then ratio will be (count / average_count)
+                return producedBlocksCount.Mul(producedBlocksCount).Div(averageProducedBlocksCount);
+            }
+
+            return producedBlocksCount;
         }
     }
 }

--- a/test/AElf.Contracts.Economic.AEDPoSExtension.Tests/TreasuryDistributionTests.cs
+++ b/test/AElf.Contracts.Economic.AEDPoSExtension.Tests/TreasuryDistributionTests.cs
@@ -90,12 +90,12 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
 
             // Check amount distributed to each scheme.
             {
-                // Miner Basic Reward: 10%
+                // Miner Basic Reward: 10% + 5% （from Flexible Reward）
                 {
                     var distributedInformation =
                         await GetDistributedInformationAsync(_schemes[SchemeType.MinerBasicReward].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
-                    amount.ShouldBe(distributedAmount / 10);
+                    amount.ShouldBe(distributedAmount / 10 + distributedAmount / 20);
                 }
 
                 // Backup Subsidy: 5%
@@ -106,12 +106,12 @@ namespace AElf.Contracts.Economic.AEDPoSExtension.Tests
                     amount.ShouldBe(distributedAmount / 20);
                 }
 
-                // Citizen Welfare: -75% (Burned) + (-5%) (from Flexible Reward)
+                // Citizen Welfare: -75% (Burned)
                 {
                     var distributedInformation =
                         await GetDistributedInformationAsync(_schemes[SchemeType.CitizenWelfare].SchemeId, period);
                     var amount = distributedInformation.AmountsMap[EconomicTestConstants.TokenSymbol];
-                    amount.ShouldBe(-distributedAmount * 4 / 5);
+                    amount.ShouldBe(-distributedAmount * 3 / 4);
                 }
 
                 // Flexible Reward: 5%

--- a/test/AElf.Contracts.Economic.TestBase/Contracts.cs
+++ b/test/AElf.Contracts.Economic.TestBase/Contracts.cs
@@ -19,7 +19,7 @@ namespace AElf.Contracts.Economic.TestBase
         Vote,
         TokenHolder
     }
-    
+
     public enum TestContracts
     {
         BasicFunction,
@@ -28,7 +28,7 @@ namespace AElf.Contracts.Economic.TestBase
         MethodCallThreshold,
         ResourceSpender
     }
-    
+
     public enum ProfitType
     {
         Treasury,
@@ -36,7 +36,7 @@ namespace AElf.Contracts.Economic.TestBase
         BackupSubsidy,
         CitizenWelfare,
         BasicMinerReward,
-        VotesWeightReward,
-        ReElectionReward
+        WelcomeReward,
+        FlexibleReward,
     }
 }

--- a/test/AElf.Contracts.Economic.TestBase/ContractsPreparation.cs
+++ b/test/AElf.Contracts.Economic.TestBase/ContractsPreparation.cs
@@ -338,8 +338,8 @@ namespace AElf.Contracts.Economic.TestBase
                     {ProfitType.Treasury, profitIds[0]},
                     {ProfitType.MinerReward, profitIds[1]},
                     {ProfitType.BasicMinerReward, profitIds[2]},
-                    {ProfitType.VotesWeightReward, profitIds[3]},
-                    {ProfitType.ReElectionReward, profitIds[4]},
+                    {ProfitType.FlexibleReward, profitIds[3]},
+                    {ProfitType.WelcomeReward, profitIds[4]},
                 };
             }
             {

--- a/test/AElf.Contracts.EconomicSystem.Tests/BVT/AETCTest.cs
+++ b/test/AElf.Contracts.EconomicSystem.Tests/BVT/AETCTest.cs
@@ -41,13 +41,13 @@ namespace AElf.Contracts.EconomicSystem.Tests.BVT
             reward.SubSchemes.First(s => s.SchemeId == ProfitItemsIds[ProfitType.BasicMinerReward]).Shares
                 .ShouldBe(ElectionContractConstants.BasicMinerRewardWeight);
             // VotesWeightReward (Shares 1) -> Reward
-            reward.SubSchemes.Select(s => s.SchemeId).ShouldContain(ProfitItemsIds[ProfitType.VotesWeightReward]);
-            reward.SubSchemes.First(s => s.SchemeId == ProfitItemsIds[ProfitType.VotesWeightReward]).Shares
-                .ShouldBe(ElectionContractConstants.VotesWeightRewardWeight);
+            reward.SubSchemes.Select(s => s.SchemeId).ShouldContain(ProfitItemsIds[ProfitType.FlexibleReward]);
+            reward.SubSchemes.First(s => s.SchemeId == ProfitItemsIds[ProfitType.FlexibleReward]).Shares
+                .ShouldBe(ElectionContractConstants.FlexibleRewardWeight);
             // ReElectionReward (Shares 1) -> Reward
-            reward.SubSchemes.Select(s => s.SchemeId).ShouldContain(ProfitItemsIds[ProfitType.ReElectionReward]);
-            reward.SubSchemes.First(s => s.SchemeId == ProfitItemsIds[ProfitType.ReElectionReward]).Shares
-                .ShouldBe(ElectionContractConstants.WelfareRewardWeight);
+            reward.SubSchemes.Select(s => s.SchemeId).ShouldContain(ProfitItemsIds[ProfitType.WelcomeReward]);
+            reward.SubSchemes.First(s => s.SchemeId == ProfitItemsIds[ProfitType.WelcomeReward]).Shares
+                .ShouldBe(ElectionContractConstants.WelcomeRewardWeight);
 
             // Check the balance of Treasury
             var balance = await TokenContractStub.GetBalance.CallAsync(new GetBalanceInput

--- a/test/AElf.Contracts.EconomicSystem.Tests/BVT/AETCTest.cs
+++ b/test/AElf.Contracts.EconomicSystem.Tests/BVT/AETCTest.cs
@@ -47,7 +47,7 @@ namespace AElf.Contracts.EconomicSystem.Tests.BVT
             // ReElectionReward (Shares 1) -> Reward
             reward.SubSchemes.Select(s => s.SchemeId).ShouldContain(ProfitItemsIds[ProfitType.ReElectionReward]);
             reward.SubSchemes.First(s => s.SchemeId == ProfitItemsIds[ProfitType.ReElectionReward]).Shares
-                .ShouldBe(ElectionContractConstants.ReElectionRewardWeight);
+                .ShouldBe(ElectionContractConstants.WelfareRewardWeight);
 
             // Check the balance of Treasury
             var balance = await TokenContractStub.GetBalance.CallAsync(new GetBalanceInput

--- a/test/AElf.Contracts.EconomicSystem.Tests/BVT/TreasuryBasicTests.cs
+++ b/test/AElf.Contracts.EconomicSystem.Tests/BVT/TreasuryBasicTests.cs
@@ -80,10 +80,10 @@ namespace AElf.Contracts.EconomicSystem.Tests.BVT
                 x.SchemeId == minerRewardWeightSetting.BasicMinerRewardProportionInfo.SchemeId);
             basicMinerRewardScheme.Shares.ShouldBe(2);
             var reElectionRewardScheme = subSchemes.Single(x =>
-                x.SchemeId == minerRewardWeightSetting.ReElectionRewardProportionInfo.SchemeId);
+                x.SchemeId == minerRewardWeightSetting.WelcomeRewardProportionInfo.SchemeId);
             reElectionRewardScheme.Shares.ShouldBe(1);
             var votesWeightRewardScheme = subSchemes.Single(x =>
-                x.SchemeId == minerRewardWeightSetting.VotesWeightRewardProportionInfo.SchemeId);
+                x.SchemeId == minerRewardWeightSetting.FlexibleRewardProportionInfo.SchemeId);
             votesWeightRewardScheme.Shares.ShouldBe(1);
         }
 
@@ -123,8 +123,8 @@ namespace AElf.Contracts.EconomicSystem.Tests.BVT
             
             var defaultMinerRewardWeightSetting = await TreasuryContractStub.GetMinerRewardWeightProportion.CallAsync(new Empty());
             defaultMinerRewardWeightSetting.BasicMinerRewardProportionInfo.Proportion.ShouldBe(50);
-            defaultMinerRewardWeightSetting.ReElectionRewardProportionInfo.Proportion.ShouldBe(25);
-            defaultMinerRewardWeightSetting.VotesWeightRewardProportionInfo.Proportion.ShouldBe(25);
+            defaultMinerRewardWeightSetting.WelcomeRewardProportionInfo.Proportion.ShouldBe(25);
+            defaultMinerRewardWeightSetting.FlexibleRewardProportionInfo.Proportion.ShouldBe(25);
 
             var treasuryScheme = await ProfitContractStub.GetManagingSchemeIds.CallAsync(new GetManagingSchemeIdsInput
             {
@@ -427,20 +427,22 @@ namespace AElf.Contracts.EconomicSystem.Tests.BVT
         {
             var defaultWeightSetting = await TreasuryContractStub.GetMinerRewardWeightProportion.CallAsync(new Empty());
             defaultWeightSetting.BasicMinerRewardProportionInfo.Proportion.ShouldBe(50);
-            defaultWeightSetting.ReElectionRewardProportionInfo.Proportion.ShouldBe(25);
-            defaultWeightSetting.VotesWeightRewardProportionInfo.Proportion.ShouldBe(25);
+            defaultWeightSetting.WelcomeRewardProportionInfo.Proportion.ShouldBe(25);
+            defaultWeightSetting.FlexibleRewardProportionInfo.Proportion.ShouldBe(25);
             var newWeightSetting = new MinerRewardWeightSetting
             {
                 BasicMinerRewardWeight = 1,
-                ReElectionRewardWeight = 1,
-                VotesWeightRewardWeight = 8
+                WelcomeRewardWeight = 1,
+                FlexibleRewardWeight = 8
             };
             await ExecuteProposalForParliamentTransaction(Tester, TreasuryContractAddress,
                 nameof(TreasuryContractStub.SetMinerRewardWeightSetting), newWeightSetting);
+
             var updatedWeightSetting = await TreasuryContractStub.GetMinerRewardWeightProportion.CallAsync(new Empty());
             updatedWeightSetting.BasicMinerRewardProportionInfo.Proportion.ShouldBe(10);
-            updatedWeightSetting.ReElectionRewardProportionInfo.Proportion.ShouldBe(10);
-            updatedWeightSetting.VotesWeightRewardProportionInfo.Proportion.ShouldBe(80);
+            updatedWeightSetting.WelcomeRewardProportionInfo.Proportion.ShouldBe(10);
+            updatedWeightSetting.FlexibleRewardProportionInfo.Proportion.ShouldBe(80);
+
             var minerRewardProfit =
                 await ProfitContractStub.GetScheme.CallAsync(ProfitItemsIds[ProfitType.MinerReward]);
             var subSchemes = minerRewardProfit.SubSchemes;
@@ -448,12 +450,12 @@ namespace AElf.Contracts.EconomicSystem.Tests.BVT
             var basicMinerRewardScheme = subSchemes.Single(x =>
                 x.SchemeId == updatedWeightSetting.BasicMinerRewardProportionInfo.SchemeId);
             basicMinerRewardScheme.Shares.ShouldBe(1);
-            var reElectionRewardScheme = subSchemes.Single(x =>
-                x.SchemeId == updatedWeightSetting.ReElectionRewardProportionInfo.SchemeId);
-            reElectionRewardScheme.Shares.ShouldBe(1);
-            var votesWeightRewardScheme = subSchemes.Single(x =>
-                x.SchemeId == updatedWeightSetting.VotesWeightRewardProportionInfo.SchemeId);
-            votesWeightRewardScheme.Shares.ShouldBe(8);
+            var welcomeRewardScheme = subSchemes.Single(x =>
+                x.SchemeId == updatedWeightSetting.WelcomeRewardProportionInfo.SchemeId);
+            welcomeRewardScheme.Shares.ShouldBe(1);
+            var flexibleRewardScheme = subSchemes.Single(x =>
+                x.SchemeId == updatedWeightSetting.FlexibleRewardProportionInfo.SchemeId);
+            flexibleRewardScheme.Shares.ShouldBe(8);
         }
 
         [Fact]

--- a/test/AElf.Contracts.EconomicSystem.Tests/ElectionContractConstants.cs
+++ b/test/AElf.Contracts.EconomicSystem.Tests/ElectionContractConstants.cs
@@ -7,8 +7,8 @@ namespace AElf.Contracts.EconomicSystem.Tests
         public const int MinerRewardWeight = 4;
         
         public const int BasicMinerRewardWeight = 2;
-        public const int VotesWeightRewardWeight = 1;
-        public const int WelfareRewardWeight = 1;
+        public const int FlexibleRewardWeight = 1;
+        public const int WelcomeRewardWeight = 1;
 
     }
 }

--- a/test/AElf.Contracts.EconomicSystem.Tests/ElectionContractConstants.cs
+++ b/test/AElf.Contracts.EconomicSystem.Tests/ElectionContractConstants.cs
@@ -8,7 +8,7 @@ namespace AElf.Contracts.EconomicSystem.Tests
         
         public const int BasicMinerRewardWeight = 2;
         public const int VotesWeightRewardWeight = 1;
-        public const int ReElectionRewardWeight = 1;
+        public const int WelfareRewardWeight = 1;
 
     }
 }

--- a/test/AElf.Contracts.Election.Tests/Full/ReleaseProfitsFromTreasury.cs
+++ b/test/AElf.Contracts.Election.Tests/Full/ReleaseProfitsFromTreasury.cs
@@ -22,7 +22,7 @@ namespace AElf.Contracts.Election
             long rewardAmount;
             var updatedBackupSubsidy = 0L;
             var updatedBasicReward = 0L;
-            var updatedVotesWeightReward = 0L;
+            var updatedFlexibleReward = 0L;
             var updatedCitizenWelfare = 0L;
 
             var treasuryScheme =
@@ -51,7 +51,8 @@ namespace AElf.Contracts.Election
                 // SampleKeyPairs[18...30] get 1 votes.
                 var lessVotesCandidates = ValidationDataCenterKeyPairs
                     .Skip(EconomicContractsTestConstants.InitialCoreDataCenterCount)
-                    .Take(EconomicContractsTestConstants.SupposedMinersCount - EconomicContractsTestConstants.InitialCoreDataCenterCount).ToList();
+                    .Take(EconomicContractsTestConstants.SupposedMinersCount -
+                          EconomicContractsTestConstants.InitialCoreDataCenterCount).ToList();
                 foreach (var keyPair in lessVotesCandidates)
                 {
                     await VoteToCandidate(VoterKeyPairs[0], keyPair.PublicKey.ToHex(), 100 * 86400, 1);
@@ -105,7 +106,7 @@ namespace AElf.Contracts.Election
                 // Basic reward.
                 {
                     var previousTermInformation =
-                        AEDPoSContractStub.GetPreviousTermInformation.CallAsync(new Int64Value {Value = 1}).Result;
+                        AEDPoSContractStub.GetPreviousTermInformation.CallAsync(new Int64Value { Value = 1 }).Result;
                     var releasedInformation =
                         await GetDistributedProfitsInfo(ProfitType.BasicMinerReward, currentPeriod);
                     releasedInformation.IsReleased.ShouldBeTrue();
@@ -121,35 +122,38 @@ namespace AElf.Contracts.Election
                     amount.ShouldBe(0);
                 }
 
-                // Votes weights reward.
+                // Flexible reward.
                 {
                     var releasedInformation =
-                        await GetDistributedProfitsInfo(ProfitType.VotesWeightReward, currentPeriod);
+                        await GetDistributedProfitsInfo(ProfitType.FlexibleReward, currentPeriod);
                     releasedInformation.IsReleased.ShouldBeTrue();
-                    releasedInformation.TotalShares.ShouldBe(0);
+                    // Flexible rewards went to 17 new miners.
+                    releasedInformation.TotalShares.ShouldBe(17);
                     releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
-                        .ShouldBe(-rewardAmount / 20);
+                        .ShouldBe(rewardAmount / 20);
                 }
 
-                // Amount of votes weights reward.
+                // Amount of flexible reward.
                 {
-                    var amount = await GetProfitAmount(ProfitType.VotesWeightReward);
-                    amount.ShouldBe(0);
+                    var amount = await GetProfitAmount(ProfitType.FlexibleReward);
+                    amount.ShouldBe(rewardAmount / 20 / 17);
+                    updatedFlexibleReward += rewardAmount / 20 / 17;
                 }
 
-                // Re-election reward.
+                // Welcome reward.
                 {
                     var releasedInformation =
-                        await GetDistributedProfitsInfo(ProfitType.ReElectionReward, currentPeriod);
+                        await GetDistributedProfitsInfo(ProfitType.WelcomeReward, currentPeriod);
                     releasedInformation.IsReleased.ShouldBeTrue();
-                    releasedInformation.TotalShares.ShouldBe(0);
+                    // Welcome rewards went to Citizen Welfare Reward.
+                    releasedInformation.TotalShares.ShouldBe(1);
                     releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
-                        .ShouldBe(-rewardAmount / 20);
+                        .ShouldBe(rewardAmount / 20);
                 }
 
-                // Amount of re-election reward.
+                // Amount of welcome reward.
                 {
-                    var amount = await GetProfitAmount(ProfitType.ReElectionReward);
+                    var amount = await GetProfitAmount(ProfitType.WelcomeReward);
                     amount.ShouldBe(0);
                 }
 
@@ -159,8 +163,9 @@ namespace AElf.Contracts.Election
                         await GetDistributedProfitsInfo(ProfitType.CitizenWelfare, currentPeriod);
                     releasedInformation.IsReleased.ShouldBeTrue();
                     releasedInformation.TotalShares.ShouldBe(0);
+                    // 75% + 5%
                     releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
-                        .ShouldBe(-rewardAmount * 3 / 4);
+                        .ShouldBe(-rewardAmount * 4 / 5);
                 }
 
                 // Amount of citizen welfare.
@@ -208,55 +213,45 @@ namespace AElf.Contracts.Election
                 // Basic reward.
                 {
                     var previousTermInformation =
-                        AEDPoSContractStub.GetPreviousTermInformation.CallAsync(new Int64Value {Value = 2}).Result;
+                        AEDPoSContractStub.GetPreviousTermInformation.CallAsync(new Int64Value { Value = 2 }).Result;
                     var totalProducedBlocks =
                         previousTermInformation.RealTimeMinersInformation.Values.Sum(i => i.ProducedBlocks);
                     var releasedInformation =
                         await GetDistributedProfitsInfo(ProfitType.BasicMinerReward, currentPeriod);
                     releasedInformation.TotalShares.ShouldBe(totalProducedBlocks);
                     releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
-                        .ShouldBe(rewardAmount / 10);
+                        .ShouldBe(rewardAmount / 5);
                     var amount = await GetProfitAmount(ProfitType.BasicMinerReward);
-                    updatedBasicReward += rewardAmount / 10 *
-                                          previousTermInformation
-                                              .RealTimeMinersInformation[ValidationDataCenterKeyPairs[0].PublicKey.ToHex()]
-                                              .ProducedBlocks / totalProducedBlocks;
+                    updatedBasicReward += rewardAmount / 5 *
+                        previousTermInformation
+                            .RealTimeMinersInformation[ValidationDataCenterKeyPairs[0].PublicKey.ToHex()]
+                            .ProducedBlocks / totalProducedBlocks;
                     amount.ShouldBe(updatedBasicReward);
                 }
 
-                // Votes weights reward.
+                // Flexible reward.
                 {
                     var releasedInformation =
-                        await GetDistributedProfitsInfo(ProfitType.VotesWeightReward, currentPeriod);
-                    // First 5 victories each obtained 2 votes, last 12 victories each obtained 1 vote.
-                    releasedInformation.TotalShares.ShouldBe(EconomicContractsTestConstants.InitialCoreDataCenterCount +
-                                                             EconomicContractsTestConstants.SupposedMinersCount);
+                        await GetDistributedProfitsInfo(ProfitType.FlexibleReward, currentPeriod);
+                    // Flexible rewards went to Basic Miner Reward.
+                    releasedInformation.TotalShares.ShouldBe(1);
                     releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
                         .ShouldBe(rewardAmount / 20);
                 }
 
-                // Amount of votes weights reward.
-                {
-                    var amount = await GetProfitAmount(ProfitType.VotesWeightReward);
-                    updatedVotesWeightReward +=
-                        rewardAmount / 20 * 2 / (EconomicContractsTestConstants.InitialCoreDataCenterCount +
-                                                 EconomicContractsTestConstants.SupposedMinersCount);
-                    amount.ShouldBe(updatedVotesWeightReward);
-                }
-
-                // Re-election reward.
+                // Welcome reward.
                 {
                     var releasedInformation =
-                        await GetDistributedProfitsInfo(ProfitType.ReElectionReward, currentPeriod);
+                        await GetDistributedProfitsInfo(ProfitType.WelcomeReward, currentPeriod);
                     releasedInformation.IsReleased.ShouldBeTrue();
-                    releasedInformation.TotalShares.ShouldBe(0);
+                    releasedInformation.TotalShares.ShouldBe(1);
                     releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
-                        .ShouldBe(-rewardAmount / 20);
+                        .ShouldBe(rewardAmount / 20);
                 }
 
-                // Amount of re-election reward.
+                // Amount of welcome reward.
                 {
-                    var amount = await GetProfitAmount(ProfitType.ReElectionReward);
+                    var amount = await GetProfitAmount(ProfitType.WelcomeReward);
                     amount.ShouldBe(0);
                 }
 
@@ -269,7 +264,7 @@ namespace AElf.Contracts.Election
 
                     // Amount of citizen welfare.
                     var electorVote = await ElectionContractStub.GetElectorVoteWithRecords.CallAsync(new StringValue
-                        {Value = VoterKeyPairs[0].PublicKey.ToHex()});
+                        { Value = VoterKeyPairs[0].PublicKey.ToHex() });
                     var electorWeights = electorVote.ActiveVotingRecords.Sum(r => r.Weight);
                     electorWeights.ShouldBe(releasedInformation.TotalShares);
                     var amount = await GetProfitAmount(ProfitType.CitizenWelfare);
@@ -313,59 +308,57 @@ namespace AElf.Contracts.Election
                     amount.ShouldBe(updatedBackupSubsidy);
                 }
 
+
+                // Flexible reward.
+                {
+                    var releasedInformation =
+                        await GetDistributedProfitsInfo(ProfitType.FlexibleReward, currentPeriod);
+                    // Flexible rewards went to Basic Miner Reward.
+                    releasedInformation.TotalShares.ShouldBe(1);
+                    releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
+                        .ShouldBe(rewardAmount / 20);
+                }
+
+                // Amount of flexible reward.
+                {
+                    var amount = await GetProfitAmount(ProfitType.FlexibleReward);
+                    amount.ShouldBe(updatedFlexibleReward);
+                }
+
+                // Welcome reward.
+                {
+                    var releasedInformation =
+                        await GetDistributedProfitsInfo(ProfitType.WelcomeReward, currentPeriod);
+                    releasedInformation.IsReleased.ShouldBeTrue();
+                    releasedInformation.TotalShares.ShouldBe(1);
+                    releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
+                        .ShouldBe(rewardAmount / 20);
+                }
+
+                // Amount of welcome reward.
+                {
+                    var amount = await GetProfitAmount(ProfitType.WelcomeReward);
+                    amount.ShouldBe(0);
+                }
+
                 // Basic reward.
                 {
                     var previousTermInformation =
-                        AEDPoSContractStub.GetPreviousTermInformation.CallAsync(new Int64Value {Value = 3}).Result;
+                        AEDPoSContractStub.GetPreviousTermInformation.CallAsync(new Int64Value { Value = 3 }).Result;
                     var totalProducedBlocks =
                         previousTermInformation.RealTimeMinersInformation.Values.Sum(i => i.ProducedBlocks);
                     var releasedInformation =
                         await GetDistributedProfitsInfo(ProfitType.BasicMinerReward, currentPeriod);
                     releasedInformation.TotalShares.ShouldBe(totalProducedBlocks);
+                    // 10% + 5% (from Flexible Reward) + 5% (from Welcome Reward)
                     releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
-                        .ShouldBe(rewardAmount / 10);
+                        .ShouldBe(rewardAmount / 5);
                     var amount = await GetProfitAmount(ProfitType.BasicMinerReward);
-                    updatedBasicReward += rewardAmount / 10 *
-                                          previousTermInformation
-                                              .RealTimeMinersInformation[ValidationDataCenterKeyPairs[0].PublicKey.ToHex()]
-                                              .ProducedBlocks / totalProducedBlocks;
+                    updatedBasicReward += rewardAmount / 5 *
+                        previousTermInformation
+                            .RealTimeMinersInformation[ValidationDataCenterKeyPairs[0].PublicKey.ToHex()]
+                            .ProducedBlocks / totalProducedBlocks;
                     amount.ShouldBe(updatedBasicReward);
-                }
-
-                // Votes weights reward.
-                {
-                    var releasedInformation =
-                        await GetDistributedProfitsInfo(ProfitType.VotesWeightReward, currentPeriod);
-                    // First 5 victories each obtained 2 votes, last 4 victories each obtained 1 vote.
-                    releasedInformation.TotalShares.ShouldBe(EconomicContractsTestConstants.InitialCoreDataCenterCount +
-                                                             EconomicContractsTestConstants.SupposedMinersCount);
-                    releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
-                        .ShouldBe(rewardAmount / 20);
-                }
-
-                // Amount of votes weights reward.
-                {
-                    var amount = await GetProfitAmount(ProfitType.VotesWeightReward);
-                    updatedVotesWeightReward +=
-                        rewardAmount / 20 * 2 / (EconomicContractsTestConstants.InitialCoreDataCenterCount +
-                                                 EconomicContractsTestConstants.SupposedMinersCount);
-                    amount.ShouldBe(updatedVotesWeightReward);
-                }
-
-                // Re-election reward.
-                {
-                    var releasedInformation =
-                        await GetDistributedProfitsInfo(ProfitType.ReElectionReward, currentPeriod);
-                    releasedInformation.IsReleased.ShouldBeTrue();
-                    releasedInformation.TotalShares.ShouldBe(EconomicContractsTestConstants.SupposedMinersCount);
-                    releasedInformation.AmountsMap[EconomicContractsTestConstants.NativeTokenSymbol]
-                        .ShouldBe(rewardAmount / 20);
-                }
-
-                // Amount of re-election reward.
-                {
-                    var amount = await GetProfitAmount(ProfitType.ReElectionReward);
-                    amount.ShouldBe(rewardAmount / 20 / EconomicContractsTestConstants.SupposedMinersCount);
                 }
 
                 // Citizen welfare.
@@ -377,7 +370,7 @@ namespace AElf.Contracts.Election
 
                     // Amount of citizen welfare.
                     var electorVote = await ElectionContractStub.GetElectorVoteWithRecords.CallAsync(new StringValue
-                        {Value = VoterKeyPairs[0].PublicKey.ToHex()});
+                        { Value = VoterKeyPairs[0].PublicKey.ToHex() });
                     var electorWeights = electorVote.ActiveVotingRecords.Sum(r => r.Weight);
                     electorWeights.ShouldBe(releasedInformation.TotalShares);
                     var amount = await GetProfitAmount(ProfitType.CitizenWelfare);
@@ -440,21 +433,21 @@ namespace AElf.Contracts.Election
                     })).Value;
                     basicMinerRewardAmount.ShouldBeGreaterThan(0);
 
-                    //vote Shares - 10%
-                    var votesWeightRewardAmount = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
+                    //flexible Shares - 10%
+                    var flexibleRewardWeight = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
                     {
-                        SchemeId = ProfitItemsIds[ProfitType.VotesWeightReward],
+                        SchemeId = ProfitItemsIds[ProfitType.FlexibleReward],
                         Symbol = "ELF"
                     })).Value;
-                    votesWeightRewardAmount.ShouldBeGreaterThan(0);
+                    flexibleRewardWeight.ShouldBeGreaterThan(0);
 
-                    //re-election Shares - 10%
-                    var reElectionBalance = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
+                    //welcome Shares - 10%
+                    var welcomeBalance = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
                     {
-                        SchemeId = ProfitItemsIds[ProfitType.ReElectionReward],
+                        SchemeId = ProfitItemsIds[ProfitType.WelcomeReward],
                         Symbol = "ELF"
                     })).Value;
-                    reElectionBalance.ShouldBeGreaterThan(0);
+                    welcomeBalance.ShouldBe(0);
 
                     //backup Shares - 20%
                     var backupBalance = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
@@ -474,17 +467,10 @@ namespace AElf.Contracts.Election
 
                     var voteResult = await profitTester.ClaimProfits.SendAsync(new ClaimProfitsInput
                     {
-                        SchemeId = ProfitItemsIds[ProfitType.VotesWeightReward],
+                        SchemeId = ProfitItemsIds[ProfitType.FlexibleReward],
                     });
                     var voteSize = voteResult.Transaction.Size();
                     voteResult.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
-
-                    var reElectionResult = await profitTester.ClaimProfits.SendAsync(new ClaimProfitsInput
-                    {
-                        SchemeId = ProfitItemsIds[ProfitType.ReElectionReward],
-                    });
-                    var reElectionSize = reElectionResult.Transaction.Size();
-                    reElectionResult.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
 
                     var backupResult = await profitTester.ClaimProfits.SendAsync(new ClaimProfitsInput
                     {
@@ -498,9 +484,9 @@ namespace AElf.Contracts.Election
                         Owner = Address.FromPublicKey(miner.PublicKey),
                         Symbol = EconomicContractsTestConstants.NativeTokenSymbol
                     })).Balance;
-                    var sizeFees = (profitSize + voteSize + reElectionSize + backSize) * txSizeFeeUnitPrice;
-                    afterToken.ShouldBe(beforeToken + basicMinerRewardAmount + votesWeightRewardAmount +
-                                        reElectionBalance + backupBalance - txFee * 4 - sizeFees);
+                    var sizeFees = (profitSize + voteSize + backSize) * txSizeFeeUnitPrice;
+                    afterToken.ShouldBe(beforeToken + basicMinerRewardAmount + flexibleRewardWeight +
+                        welcomeBalance + backupBalance - txFee * 3 - sizeFees);
                 }
             }
 
@@ -527,21 +513,21 @@ namespace AElf.Contracts.Election
                     })).Value;
                     basicMinerRewardAmount.ShouldBeGreaterThan(0);
 
-                    //vote Shares - 75%
-                    var votesWeightRewardAmount = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
+                    //flexible Shares - 75%
+                    var flexibleRewardWeight = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
                     {
-                        SchemeId = ProfitItemsIds[ProfitType.VotesWeightReward],
+                        SchemeId = ProfitItemsIds[ProfitType.FlexibleReward],
                         Symbol = "ELF"
                     })).Value;
-                    votesWeightRewardAmount.ShouldBeGreaterThan(0);
+                    flexibleRewardWeight.ShouldBe(0);
 
-                    //re-election Shares - 5%
-                    var reElectionBalance = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
+                    //welcome Shares - 5%
+                    var welcomeBalance = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
                     {
-                        SchemeId = ProfitItemsIds[ProfitType.ReElectionReward],
+                        SchemeId = ProfitItemsIds[ProfitType.WelcomeReward],
                         Symbol = "ELF"
                     })).Value;
-                    reElectionBalance.ShouldBeGreaterThan(0);
+                    welcomeBalance.ShouldBe(0);
 
                     //backup Shares - 5%
                     var backupBalance = (await profitTester.GetProfitAmount.CallAsync(new GetProfitAmountInput
@@ -566,7 +552,7 @@ namespace AElf.Contracts.Election
                         {
                             Owner = Address.FromPublicKey(miner.PublicKey),
                             Symbol = EconomicContractsTestConstants.NativeTokenSymbol
-                        })).Balance; 
+                        })).Balance;
                         sizeFee = profitSize * txSizeFeeUnitPrice;
                         balance.ShouldBe(beforeToken + basicMinerRewardAmount - txFee - sizeFee);
                         balance.ShouldBe(beforeToken + basicMinerRewardAmount - txFee);
@@ -574,7 +560,7 @@ namespace AElf.Contracts.Election
 
                     var voteResult = await profitTester.ClaimProfits.SendAsync(new ClaimProfitsInput
                     {
-                        SchemeId = ProfitItemsIds[ProfitType.VotesWeightReward],
+                        SchemeId = ProfitItemsIds[ProfitType.FlexibleReward],
                     });
                     var voteSize = voteResult.Transaction.Size();
                     voteResult.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
@@ -586,26 +572,18 @@ namespace AElf.Contracts.Election
                             Symbol = EconomicContractsTestConstants.NativeTokenSymbol
                         })).Balance;
                         sizeFee = (profitSize + voteSize) * txSizeFeeUnitPrice;
-                        balance1.ShouldBe(beforeToken + basicMinerRewardAmount + votesWeightRewardAmount
+                        balance1.ShouldBe(beforeToken + basicMinerRewardAmount + flexibleRewardWeight
                                           - 2 * txFee - sizeFee);
                     }
-
-                    var reElectionResult = await profitTester.ClaimProfits.SendAsync(new ClaimProfitsInput
-                    {
-                        SchemeId = ProfitItemsIds[ProfitType.ReElectionReward],
-                    });
-                    var reElectionSize = reElectionResult.Transaction.Size();
-                    reElectionResult.TransactionResult.Status.ShouldBe(TransactionResultStatus.Mined);
-
                     {
                         var balance = (await TokenContractStub.GetBalance.CallAsync(new GetBalanceInput
                         {
                             Owner = Address.FromPublicKey(miner.PublicKey),
                             Symbol = EconomicContractsTestConstants.NativeTokenSymbol
                         })).Balance;
-                        sizeFee = (profitSize + voteSize + reElectionSize) * txSizeFeeUnitPrice;
-                        balance.ShouldBe(beforeToken + basicMinerRewardAmount + votesWeightRewardAmount +
-                                         reElectionBalance - 3 * txFee - sizeFee);
+                        sizeFee = (profitSize + voteSize) * txSizeFeeUnitPrice;
+                        balance.ShouldBe(beforeToken + basicMinerRewardAmount + flexibleRewardWeight +
+                            welcomeBalance - 2 * txFee - sizeFee);
                     }
 
                     var backupResult = await profitTester.ClaimProfits.SendAsync(new ClaimProfitsInput
@@ -621,9 +599,9 @@ namespace AElf.Contracts.Election
                             Owner = Address.FromPublicKey(miner.PublicKey),
                             Symbol = EconomicContractsTestConstants.NativeTokenSymbol
                         })).Balance;
-                        sizeFee = (profitSize + voteSize + reElectionSize + backSize) * txSizeFeeUnitPrice;
-                        balance.ShouldBe(beforeToken + basicMinerRewardAmount + votesWeightRewardAmount +
-                                         reElectionBalance + backupBalance - 4 *txFee - sizeFee);
+                        sizeFee = (profitSize + voteSize + backSize) * txSizeFeeUnitPrice;
+                        balance.ShouldBe(beforeToken + basicMinerRewardAmount + flexibleRewardWeight +
+                            welcomeBalance + backupBalance - 3 * txFee - sizeFee);
                     }
                 }
             }

--- a/test/AElf.Contracts.Profit.Tests/ProfitTests.cs
+++ b/test/AElf.Contracts.Profit.Tests/ProfitTests.cs
@@ -354,24 +354,6 @@ namespace AElf.Contracts.Profit
                     });
                 removeSubSchemeResult.TransactionResult.Error.ShouldContain("Two schemes cannot be same");
             }
-
-            //scheme dose not exit
-            {
-                var removeSubSchemeResult = await creator.RemoveSubScheme.SendWithExceptionAsync(
-                    new RemoveSubSchemeInput
-                    {
-                        SchemeId = schemeId,
-                        SubSchemeId = new Hash(),
-                    });
-                removeSubSchemeResult.TransactionResult.Error.ShouldContain("Scheme not found");
-
-                removeSubSchemeResult = await creator.RemoveSubScheme.SendWithExceptionAsync(new RemoveSubSchemeInput
-                {
-                    SchemeId = new Hash(),
-                    SubSchemeId = subSchemeId1,
-                });
-                removeSubSchemeResult.TransactionResult.Error.ShouldContain("Scheme not found");
-            }
         }
 
         [Fact]


### PR DESCRIPTION
# Change two sub-schemes of Miner Reward

Origin Re-Election Reward -> Welcome Reward
Origin Votes-Weight Reward -> Flexible Reward

## Welcome Reward
This dividend scheme is for the newly elected miner.
If there're any new miners elected for the next term, then dividends of the Welcome Reward will go to the new miners.
Otherwise, dividends will go to Basic Miner Reward.
Check: https://github.com/AElfProject/AElf/blob/eff6d679ac88cff00f692dcd6122eabb4855d451/contract/AElf.Contracts.Treasury/TreasuryContract.cs#L514

## Flexible Reward
This dividend scheme is for encouraging electors to vote for new miners.
If there're any new miners elected for the next term, then dividends of the Flexible Reward will go to the Welfare Reward (which is for voters).
Otherwise, dividends will go to Basic Miner Reward.
Check:
https://github.com/AElfProject/AElf/blob/eff6d679ac88cff00f692dcd6122eabb4855d451/contract/AElf.Contracts.Treasury/TreasuryContract.cs#L563

# Cut shares of miners who missed too many blocks

Tune the logic of calculating shares of Basic Miner Reward.

If the produced_blocks_count of this miner is less than 4/5 of the average, cut a bit shares according to the actual ratio.
And if the produced_blocks_count of this miner is less than 1/2 of the average, this miner won't share the Basic Miner Reward at all.

Check:
https://github.com/AElfProject/AElf/blob/eff6d679ac88cff00f692dcd6122eabb4855d451/contract/AElf.Contracts.Treasury/TreasuryContract.cs#L463