### PR TITLE
Enable dependabot to get security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "nuget" 
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically

Having knowledge about vulnerabilities of the dependencies helps the project owners decide on their
dependencies security posture to make decisions.

If the project decides to get updates only on security updates and not on any version updates then
setting these options would not open any PR 's open-pull-requests-limit: 0
