### PR TITLE
.Net Standard 2.1 compatibility for AElf.Cryptography & AElf.Types

### DIFF
--- a/src/AElf.Cryptography/AElf.Cryptography.csproj
+++ b/src/AElf.Cryptography/AElf.Cryptography.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <PackageId>AElf.Cryptography</PackageId>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Description>Cryptographic primitives used in AElf.</Description>

--- a/src/AElf.Cryptography/Core/Exceptions.cs
+++ b/src/AElf.Cryptography/Core/Exceptions.cs
@@ -1,28 +1,33 @@
 using System;
 
-namespace AElf.Cryptography.Core;
+namespace AElf.Cryptography.Core
+{
 
-public class InvalidSerializedPublicKeyException : Exception
-{
-}
-public class FailedToSerializePointException : Exception
-{
-}
-public class FailedToCreatePointFromScalarException : Exception
-{
-}
-public class FailedToNegatePublicKeyException : Exception
-{
-}
+    public class InvalidSerializedPublicKeyException : Exception
+    {
+    }
 
-public class FailedToCombinePublicKeysException : Exception
-{
-}
+    public class FailedToSerializePointException : Exception
+    {
+    }
 
-public class FailedToMultiplyScalarException : Exception
-{
-}
+    public class FailedToCreatePointFromScalarException : Exception
+    {
+    }
 
-public class FailedToGetNonceException : Exception
-{
+    public class FailedToNegatePublicKeyException : Exception
+    {
+    }
+
+    public class FailedToCombinePublicKeysException : Exception
+    {
+    }
+
+    public class FailedToMultiplyScalarException : Exception
+    {
+    }
+
+    public class FailedToGetNonceException : Exception
+    {
+    }
 }

--- a/src/AElf.Cryptography/Core/Helpers.cs
+++ b/src/AElf.Cryptography/Core/Helpers.cs
@@ -2,62 +2,64 @@ using System;
 using System.Linq;
 using Org.BouncyCastle.Math;
 
-namespace AElf.Cryptography.Core;
-
-public static class Helpers
+namespace AElf.Cryptography.Core
 {
-    public static byte[] AddLeadingZeros(byte[] data, int requiredLength)
+
+    public static class Helpers
     {
-        var zeroBytesLength = requiredLength - data.Length;
-        if (zeroBytesLength <= 0) return data;
-        var output = new byte[requiredLength];
-        Buffer.BlockCopy(data, 0, output, zeroBytesLength, data.Length);
-        for (int i = zeroBytesLength - 1; i >= 0; i--)
+        public static byte[] AddLeadingZeros(byte[] data, int requiredLength)
         {
-            output[i] = 0x0;
+            var zeroBytesLength = requiredLength - data.Length;
+            if (zeroBytesLength <= 0) return data;
+            var output = new byte[requiredLength];
+            Buffer.BlockCopy(data, 0, output, zeroBytesLength, data.Length);
+            for (int i = zeroBytesLength - 1; i >= 0; i--)
+            {
+                output[i] = 0x0;
+            }
+
+            return output;
         }
 
-        return output;
-    }
 
-
-    public static byte[] Int2Bytes(BigInteger v, int rolen)
-    {
-        var result = v.ToByteArray();
-        if (result.Length < rolen)
+        public static byte[] Int2Bytes(BigInteger v, int rolen)
         {
-            return AddLeadingZeros(result, rolen);
+            var result = v.ToByteArray();
+            if (result.Length < rolen)
+            {
+                return AddLeadingZeros(result, rolen);
+            }
+
+            if (result.Length > rolen)
+            {
+                var skipLength = result.Length - rolen;
+                return result.Skip(skipLength).ToArray();
+            }
+
+            return result;
         }
 
-        if (result.Length > rolen)
+        public static BigInteger Bits2Int(byte[] inputBytes, int qlen)
         {
-            var skipLength = result.Length - rolen;
-            return result.Skip(skipLength).ToArray();
+            var output = new BigInteger(1, inputBytes);
+            if (inputBytes.Length * 8 > qlen)
+            {
+                return output.ShiftRight(inputBytes.Length * 8 - qlen);
+            }
+
+            return output;
         }
 
-        return result;
-    }
-
-    public static BigInteger Bits2Int(byte[] inputBytes, int qlen)
-    {
-        var output = new BigInteger(1, inputBytes);
-        if (inputBytes.Length * 8 > qlen)
+        public static byte[] Bits2Bytes(byte[] input, BigInteger q, int rolen)
         {
-            return output.ShiftRight(inputBytes.Length * 8 - qlen);
+            var z1 = Bits2Int(input, q.BitLength);
+            var z2 = z1.Subtract(q);
+            if (z2.SignValue == -1)
+            {
+                return Int2Bytes(z1, rolen);
+            }
+
+            return Int2Bytes(z2, rolen);
         }
-
-        return output;
-    }
-
-    public static byte[] Bits2Bytes(byte[] input, BigInteger q, int rolen)
-    {
-        var z1 = Bits2Int(input, q.BitLength);
-        var z2 = z1.Subtract(q);
-        if (z2.SignValue == -1)
-        {
-            return Int2Bytes(z1, rolen);
-        }
-
-        return Int2Bytes(z2, rolen);
     }
 }

--- a/src/AElf.Cryptography/Core/IECCurve.cs
+++ b/src/AElf.Cryptography/Core/IECCurve.cs
@@ -1,15 +1,17 @@
 using System;
 
-namespace AElf.Cryptography.Core;
-
-public interface IECCurve : IDisposable
+namespace AElf.Cryptography.Core
 {
-    IECPoint MultiplyScalar(IECPoint point, IECScalar scalar);
-    IECPoint GetPoint(IECScalar scalar);
-    byte[] SerializePoint(IECPoint point, bool compressed);
-    IECPoint Add(IECPoint point1, IECPoint point2);
-    IECPoint Sub(IECPoint point1, IECPoint point2);
-    IECPoint DeserializePoint(byte[] input);
-    IECScalar DeserializeScalar(byte[] input);
-    byte[] GetNonce(IECScalar privateKey, byte[] hash);
+
+    public interface IECCurve : IDisposable
+    {
+        IECPoint MultiplyScalar(IECPoint point, IECScalar scalar);
+        IECPoint GetPoint(IECScalar scalar);
+        byte[] SerializePoint(IECPoint point, bool compressed);
+        IECPoint Add(IECPoint point1, IECPoint point2);
+        IECPoint Sub(IECPoint point1, IECPoint point2);
+        IECPoint DeserializePoint(byte[] input);
+        IECScalar DeserializeScalar(byte[] input);
+        byte[] GetNonce(IECScalar privateKey, byte[] hash);
+    }
 }

--- a/src/AElf.Cryptography/Core/IECPoint.cs
+++ b/src/AElf.Cryptography/Core/IECPoint.cs
@@ -1,6 +1,8 @@
-namespace AElf.Cryptography.Core;
-
-public interface IECPoint
+namespace AElf.Cryptography.Core
 {
-    byte[] Representation { get; }
+
+    public interface IECPoint
+    {
+        byte[] Representation { get; }
+    }
 }

--- a/src/AElf.Cryptography/Core/IECScalar.cs
+++ b/src/AElf.Cryptography/Core/IECScalar.cs
@@ -1,6 +1,8 @@
-namespace AElf.Cryptography.Core;
-
-public interface IECScalar
+namespace AElf.Cryptography.Core
 {
-    byte[] Representation { get; }
+
+    public interface IECScalar
+    {
+        byte[] Representation { get; }
+    }
 }

--- a/src/AElf.Cryptography/Core/Secp256k1Point.cs
+++ b/src/AElf.Cryptography/Core/Secp256k1Point.cs
@@ -1,27 +1,30 @@
 using System;
 
-namespace AElf.Cryptography.Core;
-
-public class Secp256k1Point : IECPoint
+namespace AElf.Cryptography.Core
 {
-    private readonly byte[] _nativeRep;
 
-    private Secp256k1Point(byte[] nativeRep)
+    public class Secp256k1Point : IECPoint
     {
-        _nativeRep = nativeRep;
-    }
+        private readonly byte[] _nativeRep;
 
-    public static Secp256k1Point FromNative(byte[]nativeRep)
-    {
-        return new Secp256k1Point(nativeRep);
-    }
-    public byte[] Representation
-    {
-        get
+        private Secp256k1Point(byte[] nativeRep)
         {
-            var output = new byte[_nativeRep.Length];
-            Buffer.BlockCopy(_nativeRep, 0, output, 0, _nativeRep.Length);
-            return output;
+            _nativeRep = nativeRep;
+        }
+
+        public static Secp256k1Point FromNative(byte[] nativeRep)
+        {
+            return new Secp256k1Point(nativeRep);
+        }
+
+        public byte[] Representation
+        {
+            get
+            {
+                var output = new byte[_nativeRep.Length];
+                Buffer.BlockCopy(_nativeRep, 0, output, 0, _nativeRep.Length);
+                return output;
+            }
         }
     }
 }

--- a/src/AElf.Cryptography/Core/Secp256k1Scalar.cs
+++ b/src/AElf.Cryptography/Core/Secp256k1Scalar.cs
@@ -1,28 +1,31 @@
 using System;
 
-namespace AElf.Cryptography.Core;
-
-public class Secp256k1Scalar:IECScalar
+namespace AElf.Cryptography.Core
 {
-    private readonly byte[] _nativeRep;
 
-    private Secp256k1Scalar(byte[] nativeRep)
+    public class Secp256k1Scalar : IECScalar
     {
-        _nativeRep = nativeRep;
-    }
+        private readonly byte[] _nativeRep;
 
-    public static Secp256k1Scalar FromNative(byte[]nativeRep)
-    {
-        return new Secp256k1Scalar(nativeRep);
-    }
-    public byte[] Representation
-    {
-        get
+        private Secp256k1Scalar(byte[] nativeRep)
         {
-            var output = new byte[_nativeRep.Length];
-            Buffer.BlockCopy(_nativeRep, 0, output, 0, _nativeRep.Length);
-            return output;
+            _nativeRep = nativeRep;
         }
+
+        public static Secp256k1Scalar FromNative(byte[] nativeRep)
+        {
+            return new Secp256k1Scalar(nativeRep);
+        }
+
+        public byte[] Representation
+        {
+            get
+            {
+                var output = new byte[_nativeRep.Length];
+                Buffer.BlockCopy(_nativeRep, 0, output, 0, _nativeRep.Length);
+                return output;
+            }
+        }
+
     }
-    
 }

--- a/src/AElf.Cryptography/Core/Sha256HasherFactory.cs
+++ b/src/AElf.Cryptography/Core/Sha256HasherFactory.cs
@@ -1,12 +1,14 @@
 using System.Security.Cryptography;
 using AElf.Cryptography.ECVRF;
 
-namespace AElf.Cryptography.Core;
-
-public class Sha256HasherFactory:IHasherFactory
+namespace AElf.Cryptography.Core
 {
-    public HashAlgorithm Create()
+
+    public class Sha256HasherFactory : IHasherFactory
     {
-        return SHA256.Create();
+        public HashAlgorithm Create()
+        {
+            return SHA256.Create();
+        }
     }
 }

--- a/src/AElf.Cryptography/CryptoHelper.cs
+++ b/src/AElf.Cryptography/CryptoHelper.cs
@@ -10,185 +10,188 @@ using Secp256k1Net;
 using Virgil.Crypto;
 using ECParameters = AElf.Cryptography.ECDSA.ECParameters;
 
-namespace AElf.Cryptography;
-
-public static class CryptoHelper
+namespace AElf.Cryptography
 {
-    private static readonly Secp256k1 Secp256K1 = new();
 
-    // ReaderWriterLock for thread-safe with Secp256k1 APIs
-    private static readonly ReaderWriterLock Lock = new();
-
-    private static readonly Vrf<Secp256k1Curve, Sha256HasherFactory> Vrf = new(new VrfConfig(0xfe, ECParameters.Curve));
-
-    static CryptoHelper()
+    public static class CryptoHelper
     {
-        AppDomain.CurrentDomain.ProcessExit += (sender, arg) => { Secp256K1.Dispose(); };
-    }
+        private static readonly Secp256k1 Secp256K1 = new Secp256k1();
 
-    public static ECKeyPair FromPrivateKey(byte[] privateKey)
-    {
-        if (privateKey == null || privateKey.Length != 32)
-            throw new InvalidPrivateKeyException(
-                $"Private key has to have length of 32. Current length is {privateKey?.Length}.");
+        // ReaderWriterLock for thread-safe with Secp256k1 APIs
+        private static readonly ReaderWriterLock Lock = new ReaderWriterLock();
 
-        try
+        private static readonly Vrf<Secp256k1Curve, Sha256HasherFactory> Vrf =
+            new Vrf<Secp256k1Curve, Sha256HasherFactory>(new VrfConfig(0xfe, ECParameters.Curve));
+
+        static CryptoHelper()
         {
-            Lock.AcquireWriterLock(Timeout.Infinite);
-            var secp256K1PubKey = new byte[64];
-
-            if (!Secp256K1.PublicKeyCreate(secp256K1PubKey, privateKey))
-                throw new InvalidPrivateKeyException("Create public key failed.");
-            var pubKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
-            if (!Secp256K1.PublicKeySerialize(pubKey, secp256K1PubKey))
-                throw new PublicKeyOperationException("Serialize public key failed.");
-            return new ECKeyPair(privateKey, pubKey);
+            AppDomain.CurrentDomain.ProcessExit += (sender, arg) => { Secp256K1.Dispose(); };
         }
-        finally
-        {
-            Lock.ReleaseWriterLock();
-        }
-    }
 
-    public static ECKeyPair GenerateKeyPair()
-    {
-        try
+        public static ECKeyPair FromPrivateKey(byte[] privateKey)
         {
-            Lock.AcquireWriterLock(Timeout.Infinite);
-            var privateKey = new byte[32];
-            var secp256K1PubKey = new byte[64];
+            if (privateKey == null || privateKey.Length != 32)
+                throw new InvalidPrivateKeyException(
+                    $"Private key has to have length of 32. Current length is {privateKey?.Length}.");
 
-            // Generate a private key.
-            var rnd = RandomNumberGenerator.Create();
-            do
+            try
             {
-                rnd.GetBytes(privateKey);
-            } while (!Secp256K1.SecretKeyVerify(privateKey));
+                Lock.AcquireWriterLock(Timeout.Infinite);
+                var secp256K1PubKey = new byte[64];
 
-            if (!Secp256K1.PublicKeyCreate(secp256K1PubKey, privateKey))
-                throw new InvalidPrivateKeyException("Create public key failed.");
-            var pubKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
-            if (!Secp256K1.PublicKeySerialize(pubKey, secp256K1PubKey))
-                throw new PublicKeyOperationException("Serialize public key failed.");
-            return new ECKeyPair(privateKey, pubKey);
+                if (!Secp256K1.PublicKeyCreate(secp256K1PubKey, privateKey))
+                    throw new InvalidPrivateKeyException("Create public key failed.");
+                var pubKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
+                if (!Secp256K1.PublicKeySerialize(pubKey, secp256K1PubKey))
+                    throw new PublicKeyOperationException("Serialize public key failed.");
+                return new ECKeyPair(privateKey, pubKey);
+            }
+            finally
+            {
+                Lock.ReleaseWriterLock();
+            }
         }
-        finally
-        {
-            Lock.ReleaseWriterLock();
-        }
-    }
 
-    public static byte[] SignWithPrivateKey(byte[] privateKey, byte[] hash)
-    {
-        try
+        public static ECKeyPair GenerateKeyPair()
         {
-            Lock.AcquireWriterLock(Timeout.Infinite);
-            var recSig = new byte[65];
-            var compactSig = new byte[65];
-            if (!Secp256K1.SignRecoverable(recSig, hash, privateKey))
-                throw new SignatureOperationException("Create a recoverable ECDSA signature failed.");
-            if (!Secp256K1.RecoverableSignatureSerializeCompact(compactSig, out var recoverId, recSig))
-                throw new SignatureOperationException("Serialize an ECDSA signature failed.");
-            compactSig[64] = (byte)recoverId; // put recover id at the last slot
-            return compactSig;
-        }
-        finally
-        {
-            Lock.ReleaseWriterLock();
-        }
-    }
+            try
+            {
+                Lock.AcquireWriterLock(Timeout.Infinite);
+                var privateKey = new byte[32];
+                var secp256K1PubKey = new byte[64];
 
-    public static bool VerifySignature(byte[] signature, byte[] data, byte[] publicKey)
-    {
-        var recoverResult = RecoverPublicKey(signature, data, out var recoverPublicKey);
-        return recoverResult && publicKey.BytesEqual(recoverPublicKey);
-    }
+                // Generate a private key.
+                var rnd = RandomNumberGenerator.Create();
+                do
+                {
+                    rnd.GetBytes(privateKey);
+                } while (!Secp256K1.SecretKeyVerify(privateKey));
 
-    public static bool RecoverPublicKey(byte[] signature, byte[] hash, out byte[] pubkey)
-    {
-        pubkey = null;
-        try
-        {
-            Lock.AcquireWriterLock(Timeout.Infinite);
-            // Recover id should be greater than or equal to 0 and less than 4
-            if (signature.Length != Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH || signature.Last() >= 4)
-                return false;
-            var pubKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
-            var recoveredPubKey = new byte[Secp256k1.PUBKEY_LENGTH];
-            var recSig = new byte[65];
-            if (!Secp256K1.RecoverableSignatureParseCompact(recSig, signature, signature.Last()))
-                return false;
-            if (!Secp256K1.Recover(recoveredPubKey, recSig, hash))
-                return false;
-            if (!Secp256K1.PublicKeySerialize(pubKey, recoveredPubKey))
-                return false;
-            pubkey = pubKey;
-            return true;
+                if (!Secp256K1.PublicKeyCreate(secp256K1PubKey, privateKey))
+                    throw new InvalidPrivateKeyException("Create public key failed.");
+                var pubKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
+                if (!Secp256K1.PublicKeySerialize(pubKey, secp256K1PubKey))
+                    throw new PublicKeyOperationException("Serialize public key failed.");
+                return new ECKeyPair(privateKey, pubKey);
+            }
+            finally
+            {
+                Lock.ReleaseWriterLock();
+            }
         }
-        finally
-        {
-            Lock.ReleaseWriterLock();
-        }
-    }
 
-    public static byte[] EncryptMessage(byte[] senderPrivateKey, byte[] receiverPublicKey, byte[] plainText)
-    {
-        var crypto = new VirgilCrypto(KeyPairType.EC_SECP256K1);
-        var ecdhKey = Ecdh(senderPrivateKey, receiverPublicKey);
-        var newKeyPair = crypto.GenerateKeys(KeyPairType.EC_SECP256K1, ecdhKey);
-        return crypto.Encrypt(plainText, newKeyPair.PublicKey);
-    }
+        public static byte[] SignWithPrivateKey(byte[] privateKey, byte[] hash)
+        {
+            try
+            {
+                Lock.AcquireWriterLock(Timeout.Infinite);
+                var recSig = new byte[65];
+                var compactSig = new byte[65];
+                if (!Secp256K1.SignRecoverable(recSig, hash, privateKey))
+                    throw new SignatureOperationException("Create a recoverable ECDSA signature failed.");
+                if (!Secp256K1.RecoverableSignatureSerializeCompact(compactSig, out var recoverId, recSig))
+                    throw new SignatureOperationException("Serialize an ECDSA signature failed.");
+                compactSig[64] = (byte)recoverId; // put recover id at the last slot
+                return compactSig;
+            }
+            finally
+            {
+                Lock.ReleaseWriterLock();
+            }
+        }
 
-    public static byte[] DecryptMessage(byte[] senderPublicKey, byte[] receiverPrivateKey, byte[] cipherText)
-    {
-        var crypto = new VirgilCrypto(KeyPairType.EC_SECP256K1);
-        var ecdhKey = Ecdh(receiverPrivateKey, senderPublicKey);
-        var newKeyPair = crypto.GenerateKeys(KeyPairType.EC_SECP256K1, ecdhKey);
-        return crypto.Decrypt(cipherText, newKeyPair.PrivateKey);
-    }
+        public static bool VerifySignature(byte[] signature, byte[] data, byte[] publicKey)
+        {
+            var recoverResult = RecoverPublicKey(signature, data, out var recoverPublicKey);
+            return recoverResult && publicKey.BytesEqual(recoverPublicKey);
+        }
 
-    public static byte[] Ecdh(byte[] privateKey, byte[] publicKey)
-    {
-        try
+        public static bool RecoverPublicKey(byte[] signature, byte[] hash, out byte[] pubkey)
         {
-            Lock.AcquireWriterLock(Timeout.Infinite);
-            var usablePublicKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
-            if (!Secp256K1.PublicKeyParse(usablePublicKey, publicKey))
-                throw new PublicKeyOperationException("Parse public key failed.");
-            var ecdhKey = new byte[Secp256k1.SERIALIZED_COMPRESSED_PUBKEY_LENGTH];
-            if (!Secp256K1.Ecdh(ecdhKey, usablePublicKey, privateKey))
-                throw new EcdhOperationException("Compute EC Diffie- secret failed.");
-            return ecdhKey;
+            pubkey = null;
+            try
+            {
+                Lock.AcquireWriterLock(Timeout.Infinite);
+                // Recover id should be greater than or equal to 0 and less than 4
+                if (signature.Length != Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH || signature.Last() >= 4)
+                    return false;
+                var pubKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
+                var recoveredPubKey = new byte[Secp256k1.PUBKEY_LENGTH];
+                var recSig = new byte[65];
+                if (!Secp256K1.RecoverableSignatureParseCompact(recSig, signature, signature.Last()))
+                    return false;
+                if (!Secp256K1.Recover(recoveredPubKey, recSig, hash))
+                    return false;
+                if (!Secp256K1.PublicKeySerialize(pubKey, recoveredPubKey))
+                    return false;
+                pubkey = pubKey;
+                return true;
+            }
+            finally
+            {
+                Lock.ReleaseWriterLock();
+            }
         }
-        finally
-        {
-            Lock.ReleaseWriterLock();
-        }
-    }
 
-    public static byte[] ECVrfProve(ECKeyPair keyPair, byte[] alpha)
-    {
-        try
+        public static byte[] EncryptMessage(byte[] senderPrivateKey, byte[] receiverPublicKey, byte[] plainText)
         {
-            Lock.AcquireWriterLock(Timeout.Infinite);
-            return Vrf.Prove(keyPair, alpha);
+            var crypto = new VirgilCrypto(KeyPairType.EC_SECP256K1);
+            var ecdhKey = Ecdh(senderPrivateKey, receiverPublicKey);
+            var newKeyPair = crypto.GenerateKeys(KeyPairType.EC_SECP256K1, ecdhKey);
+            return crypto.Encrypt(plainText, newKeyPair.PublicKey);
         }
-        finally
-        {
-            Lock.ReleaseWriterLock();
-        }
-    }
 
-    public static byte[] ECVrfVerify(byte[] publicKey, byte[] alpha, byte[] pi)
-    {
-        try
+        public static byte[] DecryptMessage(byte[] senderPublicKey, byte[] receiverPrivateKey, byte[] cipherText)
         {
-            Lock.AcquireWriterLock(Timeout.Infinite);
-            return Vrf.Verify(publicKey, alpha, pi);
+            var crypto = new VirgilCrypto(KeyPairType.EC_SECP256K1);
+            var ecdhKey = Ecdh(receiverPrivateKey, senderPublicKey);
+            var newKeyPair = crypto.GenerateKeys(KeyPairType.EC_SECP256K1, ecdhKey);
+            return crypto.Decrypt(cipherText, newKeyPair.PrivateKey);
         }
-        finally
+
+        public static byte[] Ecdh(byte[] privateKey, byte[] publicKey)
         {
-            Lock.ReleaseWriterLock();
+            try
+            {
+                Lock.AcquireWriterLock(Timeout.Infinite);
+                var usablePublicKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
+                if (!Secp256K1.PublicKeyParse(usablePublicKey, publicKey))
+                    throw new PublicKeyOperationException("Parse public key failed.");
+                var ecdhKey = new byte[Secp256k1.SERIALIZED_COMPRESSED_PUBKEY_LENGTH];
+                if (!Secp256K1.Ecdh(ecdhKey, usablePublicKey, privateKey))
+                    throw new EcdhOperationException("Compute EC Diffie- secret failed.");
+                return ecdhKey;
+            }
+            finally
+            {
+                Lock.ReleaseWriterLock();
+            }
+        }
+
+        public static byte[] ECVrfProve(ECKeyPair keyPair, byte[] alpha)
+        {
+            try
+            {
+                Lock.AcquireWriterLock(Timeout.Infinite);
+                return Vrf.Prove(keyPair, alpha);
+            }
+            finally
+            {
+                Lock.ReleaseWriterLock();
+            }
+        }
+
+        public static byte[] ECVrfVerify(byte[] publicKey, byte[] alpha, byte[] pi)
+        {
+            try
+            {
+                Lock.AcquireWriterLock(Timeout.Infinite);
+                return Vrf.Verify(publicKey, alpha, pi);
+            }
+            finally
+            {
+                Lock.ReleaseWriterLock();
+            }
         }
     }
 }

--- a/src/AElf.Cryptography/ECDSA/ECKeyPair.cs
+++ b/src/AElf.Cryptography/ECDSA/ECKeyPair.cs
@@ -1,15 +1,17 @@
 ﻿using Secp256k1Net;
 
-namespace AElf.Cryptography.ECDSA;
-
-public class ECKeyPair : IAElfAsymmetricCipherKeyPair
+namespace AElf.Cryptography.ECDSA
 {
-    internal ECKeyPair(byte[] privateKey, byte[] publicKey)
-    {
-        PublicKey = publicKey;
-        PrivateKey = privateKey.LeftPad(Secp256k1.PRIVKEY_LENGTH);
-    }
 
-    public byte[] PrivateKey { get; }
-    public byte[] PublicKey { get; }
+    public class ECKeyPair : IAElfAsymmetricCipherKeyPair
+    {
+        internal ECKeyPair(byte[] privateKey, byte[] publicKey)
+        {
+            PublicKey = publicKey;
+            PrivateKey = privateKey.LeftPad(Secp256k1.PRIVKEY_LENGTH);
+        }
+
+        public byte[] PrivateKey { get; }
+        public byte[] PublicKey { get; }
+    }
 }

--- a/src/AElf.Cryptography/ECDSA/ECParameters.cs
+++ b/src/AElf.Cryptography/ECDSA/ECParameters.cs
@@ -2,10 +2,12 @@
 using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Crypto.Parameters;
 
-namespace AElf.Cryptography.ECDSA;
-
-public static class ECParameters
+namespace AElf.Cryptography.ECDSA
 {
-    public static readonly X9ECParameters Curve = SecNamedCurves.GetByName("secp256k1");
-    public static readonly ECDomainParameters DomainParams = new(Curve.Curve, Curve.G, Curve.N, Curve.H);
+
+    public static class ECParameters
+    {
+        public static readonly X9ECParameters Curve = SecNamedCurves.GetByName("secp256k1");
+        public static readonly ECDomainParameters DomainParams = new ECDomainParameters(Curve.Curve, Curve.G, Curve.N, Curve.H);
+    }
 }

--- a/src/AElf.Cryptography/ECVRF/Exceptions.cs
+++ b/src/AElf.Cryptography/ECVRF/Exceptions.cs
@@ -1,15 +1,17 @@
 using System;
 
-namespace AElf.Cryptography.ECVRF;
-
-public class FailedToHashToCurveException : Exception
+namespace AElf.Cryptography.ECVRF
 {
-}
 
-public class InvalidProofLengthException : Exception
-{
-}
+    public class FailedToHashToCurveException : Exception
+    {
+    }
 
-public class InvalidProofException : Exception
-{
+    public class InvalidProofLengthException : Exception
+    {
+    }
+
+    public class InvalidProofException : Exception
+    {
+    }
 }

--- a/src/AElf.Cryptography/ECVRF/Types.cs
+++ b/src/AElf.Cryptography/ECVRF/Types.cs
@@ -4,35 +4,37 @@ using AElf.Cryptography.ECDSA;
 using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Math;
 
-namespace AElf.Cryptography.ECVRF;
-
-public struct ProofInput
+namespace AElf.Cryptography.ECVRF
 {
-    public IECPoint Gamma { get; set; }
-    public BigInteger C { get; set; }
-    public BigInteger S { get; set; }
-}
 
-public struct VrfConfig
-{
-    public byte SuiteString { get; private set; }
-
-    public X9ECParameters EcParameters { get; private set; }
-
-    public VrfConfig(byte suiteString, X9ECParameters ecParameters)
+    public struct ProofInput
     {
-        SuiteString = suiteString;
-        EcParameters = ecParameters;
+        public IECPoint Gamma { get; set; }
+        public BigInteger C { get; set; }
+        public BigInteger S { get; set; }
     }
-}
 
-public interface IHasherFactory
-{
-    HashAlgorithm Create();
-}
+    public struct VrfConfig
+    {
+        public byte SuiteString { get; private set; }
 
-public interface IVrf
-{
-    byte[] Prove(ECKeyPair keyPair, byte[] alpha);
-    byte[] Verify(byte[] publicKey, byte[] alpha, byte[] pi);
+        public X9ECParameters EcParameters { get; private set; }
+
+        public VrfConfig(byte suiteString, X9ECParameters ecParameters)
+        {
+            SuiteString = suiteString;
+            EcParameters = ecParameters;
+        }
+    }
+
+    public interface IHasherFactory
+    {
+        HashAlgorithm Create();
+    }
+
+    public interface IVrf
+    {
+        byte[] Prove(ECKeyPair keyPair, byte[] alpha);
+        byte[] Verify(byte[] publicKey, byte[] alpha, byte[] pi);
+    }
 }

--- a/src/AElf.Cryptography/ECVRF/Vrf.cs
+++ b/src/AElf.Cryptography/ECVRF/Vrf.cs
@@ -7,198 +7,200 @@ using AElf.Cryptography.ECDSA;
 using Org.BouncyCastle.Math;
 using Secp256k1Net;
 
-namespace AElf.Cryptography.ECVRF;
-
-public class Vrf<TCurve, THasherFactory> : IVrf where TCurve : IECCurve, new()
-    where THasherFactory : IHasherFactory, new()
+namespace AElf.Cryptography.ECVRF
 {
-    private int BitSize => _config.EcParameters.Curve.FieldSize;
-    private int QBitsLength => _config.EcParameters.N.BitLength;
-    private int N => ((BitSize + 1) / 2 + 7) / 8;
 
-    private readonly VrfConfig _config;
-    private readonly IHasherFactory _hasherFactory;
-
-    public Vrf(VrfConfig config)
+    public class Vrf<TCurve, THasherFactory> : IVrf where TCurve : IECCurve, new()
+        where THasherFactory : IHasherFactory, new()
     {
-        _config = config;
-        _hasherFactory = new THasherFactory();
-    }
+        private int BitSize => _config.EcParameters.Curve.FieldSize;
+        private int QBitsLength => _config.EcParameters.N.BitLength;
+        private int N => ((BitSize + 1) / 2 + 7) / 8;
 
-    public byte[] Prove(ECKeyPair keyPair, byte[] alpha)
-    {
-        using var curve = new TCurve();
-        var point = curve.DeserializePoint(keyPair.PublicKey);
-        var hashPoint = HashToCurveTryAndIncrement(point, alpha);
-        var gamma = curve.MultiplyScalar(hashPoint, curve.DeserializeScalar(keyPair.PrivateKey));
+        private readonly VrfConfig _config;
+        private readonly IHasherFactory _hasherFactory;
 
-        var nonce = Rfc6979Nonce(keyPair, hashPoint);
-        var kB = curve.GetPoint(nonce);
-        var kH = curve.MultiplyScalar(hashPoint, nonce);
-        var c = HashPoints(hashPoint, gamma, kB, kH);
-        var cX = c.Multiply(new BigInteger(1, keyPair.PrivateKey));
-        var s = cX.Add(new BigInteger(1, nonce.Representation)).Mod(_config.EcParameters.N);
-        return EncodeProof(gamma, c, s);
-    }
-
-    public byte[] Verify(byte[] publicKey, byte[] alpha, byte[] pi)
-    {
-        using var curve = new TCurve();
-        var proofInput = DecodeProof(pi);
-
-        var pkPoint = curve.DeserializePoint(publicKey);
-        var hashPoint = HashToCurveTryAndIncrement(pkPoint, alpha);
-        var s = curve.DeserializeScalar(proofInput.S.ToByteArray());
-        var c = curve.DeserializeScalar(proofInput.C.ToByteArray());
-
-        var sB = curve.GetPoint(s);
-        var cY = curve.MultiplyScalar(pkPoint, c);
-        var u = curve.Sub(sB, cY);
-
-        var sH = curve.MultiplyScalar(hashPoint, s);
-        var cGamma = curve.MultiplyScalar(proofInput.Gamma, c);
-        var v = curve.Sub(sH, cGamma);
-
-        var derivedC = HashPoints(hashPoint, proofInput.Gamma, u, v);
-        if (!derivedC.Equals(proofInput.C))
+        public Vrf(VrfConfig config)
         {
-            throw new InvalidProofException();
+            _config = config;
+            _hasherFactory = new THasherFactory();
         }
 
-        return GammaToHash(proofInput.Gamma);
-    }
-
-    public IECPoint HashToCurveTryAndIncrement(IECPoint point, byte[] alpha)
-    {
-        using var curve = new TCurve();
-
-        // Step 1: ctr = 0
-        var ctr = 0;
-
-        // Step 2: PK_string = point_to_string(Y)
-        var pkString = curve.SerializePoint(point, true);
-
-        // Steps 3 ~ 6
-        byte oneString = 0x01;
-        for (; ctr < 256; ctr++)
+        public byte[] Prove(ECKeyPair keyPair, byte[] alpha)
         {
+            using var curve = new TCurve();
+            var point = curve.DeserializePoint(keyPair.PublicKey);
+            var hashPoint = HashToCurveTryAndIncrement(point, alpha);
+            var gamma = curve.MultiplyScalar(hashPoint, curve.DeserializeScalar(keyPair.PrivateKey));
+
+            var nonce = Rfc6979Nonce(keyPair, hashPoint);
+            var kB = curve.GetPoint(nonce);
+            var kH = curve.MultiplyScalar(hashPoint, nonce);
+            var c = HashPoints(hashPoint, gamma, kB, kH);
+            var cX = c.Multiply(new BigInteger(1, keyPair.PrivateKey));
+            var s = cX.Add(new BigInteger(1, nonce.Representation)).Mod(_config.EcParameters.N);
+            return EncodeProof(gamma, c, s);
+        }
+
+        public byte[] Verify(byte[] publicKey, byte[] alpha, byte[] pi)
+        {
+            using var curve = new TCurve();
+            var proofInput = DecodeProof(pi);
+
+            var pkPoint = curve.DeserializePoint(publicKey);
+            var hashPoint = HashToCurveTryAndIncrement(pkPoint, alpha);
+            var s = curve.DeserializeScalar(proofInput.S.ToByteArray());
+            var c = curve.DeserializeScalar(proofInput.C.ToByteArray());
+
+            var sB = curve.GetPoint(s);
+            var cY = curve.MultiplyScalar(pkPoint, c);
+            var u = curve.Sub(sB, cY);
+
+            var sH = curve.MultiplyScalar(hashPoint, s);
+            var cGamma = curve.MultiplyScalar(proofInput.Gamma, c);
+            var v = curve.Sub(sH, cGamma);
+
+            var derivedC = HashPoints(hashPoint, proofInput.Gamma, u, v);
+            if (!derivedC.Equals(proofInput.C))
+            {
+                throw new InvalidProofException();
+            }
+
+            return GammaToHash(proofInput.Gamma);
+        }
+
+        public IECPoint HashToCurveTryAndIncrement(IECPoint point, byte[] alpha)
+        {
+            using var curve = new TCurve();
+
+            // Step 1: ctr = 0
+            var ctr = 0;
+
+            // Step 2: PK_string = point_to_string(Y)
+            var pkString = curve.SerializePoint(point, true);
+
+            // Steps 3 ~ 6
+            byte oneString = 0x01;
+            for (; ctr < 256; ctr++)
+            {
+                using var hasher = _hasherFactory.Create();
+                using var stream = new MemoryStream();
+                stream.WriteByte(_config.SuiteString);
+                stream.WriteByte(oneString);
+                stream.Write(pkString);
+                stream.Write(alpha);
+                stream.WriteByte((byte)ctr);
+                stream.Seek(0, SeekOrigin.Begin);
+                var hash = hasher.ComputeHash(stream);
+                var pkSerialized = new byte[Secp256k1.SERIALIZED_COMPRESSED_PUBKEY_LENGTH];
+                pkSerialized[0] = 0x02;
+                Buffer.BlockCopy(hash, 0, pkSerialized, 1, hash.Length);
+                try
+                {
+                    var outputPoint = curve.DeserializePoint(pkSerialized);
+                    if (_config.EcParameters.Curve.Cofactor.CompareTo(BigInteger.One) > 0)
+                    {
+                        return curve.MultiplyScalar(outputPoint,
+                            curve.DeserializeScalar(_config.EcParameters.Curve.Cofactor.ToByteArray()));
+                    }
+
+                    return outputPoint;
+                }
+                catch (InvalidSerializedPublicKeyException ex)
+                {
+                    // Ignore this exception and try the next ctr
+                }
+            }
+
+            throw new FailedToHashToCurveException();
+        }
+
+        private BigInteger HashPoints(params IECPoint[] points)
+        {
+            using var curve = new TCurve();
             using var hasher = _hasherFactory.Create();
             using var stream = new MemoryStream();
             stream.WriteByte(_config.SuiteString);
-            stream.WriteByte(oneString);
-            stream.Write(pkString);
-            stream.Write(alpha);
-            stream.WriteByte((byte)ctr);
+            stream.WriteByte(0x02);
+            foreach (var point in points)
+            {
+                stream.Write(curve.SerializePoint(point, true));
+            }
+
             stream.Seek(0, SeekOrigin.Begin);
             var hash = hasher.ComputeHash(stream);
-            var pkSerialized = new byte[Secp256k1.SERIALIZED_COMPRESSED_PUBKEY_LENGTH];
-            pkSerialized[0] = 0x02;
-            Buffer.BlockCopy(hash, 0, pkSerialized, 1, hash.Length);
-            try
+            var hashTruncated = hash.Take(N).ToArray();
+            return new BigInteger(1, hashTruncated);
+        }
+
+        private byte[] EncodeProof(IECPoint gamma, BigInteger c, BigInteger s)
+        {
+            using var curve = new TCurve();
+            var gammaBytes = curve.SerializePoint(gamma, true);
+            var cBytes = Helpers.Int2Bytes(c, N);
+            var sBytes = Helpers.Int2Bytes(s, (QBitsLength + 7) / 8);
+            var output = new byte[gammaBytes.Length + cBytes.Length + sBytes.Length];
+            Buffer.BlockCopy(gammaBytes, 0, output, 0, gammaBytes.Length);
+            Buffer.BlockCopy(cBytes, 0, output, gammaBytes.Length, cBytes.Length);
+            Buffer.BlockCopy(sBytes, 0, output, gammaBytes.Length + cBytes.Length, sBytes.Length);
+            return output;
+        }
+
+        private ProofInput DecodeProof(byte[] pi)
+        {
+            using var curve = new TCurve();
+            var ptLength = (BitSize + 7) / 8 + 1;
+            var cLength = N;
+            var sLength = (QBitsLength + 7) / 8;
+            if (pi.Length != ptLength + cLength + sLength)
             {
-                var outputPoint = curve.DeserializePoint(pkSerialized);
-                if (_config.EcParameters.Curve.Cofactor.CompareTo(BigInteger.One) > 0)
-                {
-                    return curve.MultiplyScalar(outputPoint,
-                        curve.DeserializeScalar(_config.EcParameters.Curve.Cofactor.ToByteArray()));
-                }
-
-                return outputPoint;
+                throw new InvalidProofLengthException();
             }
-            catch (InvalidSerializedPublicKeyException ex)
+
+            var gammaPoint = curve.DeserializePoint(pi.Take(ptLength).ToArray());
+            var c = new BigInteger(1, pi.Skip(ptLength).Take(cLength).ToArray());
+            var s = new BigInteger(1, pi.TakeLast(sLength).ToArray());
+            return new ProofInput()
             {
-                // Ignore this exception and try the next ctr
+                Gamma = gammaPoint,
+                C = c,
+                S = s
+            };
+        }
+
+        private byte[] GammaToHash(IECPoint gamma)
+        {
+            using var curve = new TCurve();
+
+            var gammaCof = gamma;
+            if (_config.EcParameters.Curve.Cofactor.CompareTo(BigInteger.One) > 0)
+            {
+                gammaCof = curve.MultiplyScalar(gamma,
+                    curve.DeserializeScalar(_config.EcParameters.Curve.Cofactor.ToByteArray()));
             }
+
+            var gammaCofBytes = curve.SerializePoint(gammaCof, true);
+            using var hasher = _hasherFactory.Create();
+            using var stream = new MemoryStream();
+            stream.WriteByte(_config.SuiteString);
+            stream.WriteByte(0x03);
+            stream.Write(gammaCofBytes);
+            stream.Seek(0, SeekOrigin.Begin);
+            return hasher.ComputeHash(stream);
         }
 
-        throw new FailedToHashToCurveException();
-    }
-
-    private BigInteger HashPoints(params IECPoint[] points)
-    {
-        using var curve = new TCurve();
-        using var hasher = _hasherFactory.Create();
-        using var stream = new MemoryStream();
-        stream.WriteByte(_config.SuiteString);
-        stream.WriteByte(0x02);
-        foreach (var point in points)
+        private IECScalar Rfc6979Nonce(ECKeyPair keyPair, IECPoint hashPoint)
         {
-            stream.Write(curve.SerializePoint(point, true));
+            using var curve = new TCurve();
+            using var hasher = _hasherFactory.Create();
+            var roLen = (QBitsLength + 7) / 8;
+            var hBytes = curve.SerializePoint(hashPoint, true);
+
+            var hash = hasher.ComputeHash(hBytes);
+            var bh = Helpers.Bits2Bytes(hash, _config.EcParameters.N, roLen);
+
+            var nonce = curve.GetNonce(curve.DeserializeScalar(keyPair.PrivateKey), bh);
+            return curve.DeserializeScalar(nonce);
         }
-
-        stream.Seek(0, SeekOrigin.Begin);
-        var hash = hasher.ComputeHash(stream);
-        var hashTruncated = hash.Take(N).ToArray();
-        return new BigInteger(1, hashTruncated);
-    }
-
-    private byte[] EncodeProof(IECPoint gamma, BigInteger c, BigInteger s)
-    {
-        using var curve = new TCurve();
-        var gammaBytes = curve.SerializePoint(gamma, true);
-        var cBytes = Helpers.Int2Bytes(c, N);
-        var sBytes = Helpers.Int2Bytes(s, (QBitsLength + 7) / 8);
-        var output = new byte[gammaBytes.Length + cBytes.Length + sBytes.Length];
-        Buffer.BlockCopy(gammaBytes, 0, output, 0, gammaBytes.Length);
-        Buffer.BlockCopy(cBytes, 0, output, gammaBytes.Length, cBytes.Length);
-        Buffer.BlockCopy(sBytes, 0, output, gammaBytes.Length + cBytes.Length, sBytes.Length);
-        return output;
-    }
-
-    private ProofInput DecodeProof(byte[] pi)
-    {
-        using var curve = new TCurve();
-        var ptLength = (BitSize + 7) / 8 + 1;
-        var cLength = N;
-        var sLength = (QBitsLength + 7) / 8;
-        if (pi.Length != ptLength + cLength + sLength)
-        {
-            throw new InvalidProofLengthException();
-        }
-
-        var gammaPoint = curve.DeserializePoint(pi.Take(ptLength).ToArray());
-        var c = new BigInteger(1, pi.Skip(ptLength).Take(cLength).ToArray());
-        var s = new BigInteger(1, pi.TakeLast(sLength).ToArray());
-        return new ProofInput()
-        {
-            Gamma = gammaPoint,
-            C = c,
-            S = s
-        };
-    }
-
-    private byte[] GammaToHash(IECPoint gamma)
-    {
-        using var curve = new TCurve();
-
-        var gammaCof = gamma;
-        if (_config.EcParameters.Curve.Cofactor.CompareTo(BigInteger.One) > 0)
-        {
-            gammaCof = curve.MultiplyScalar(gamma,
-                curve.DeserializeScalar(_config.EcParameters.Curve.Cofactor.ToByteArray()));
-        }
-
-        var gammaCofBytes = curve.SerializePoint(gammaCof, true);
-        using var hasher = _hasherFactory.Create();
-        using var stream = new MemoryStream();
-        stream.WriteByte(_config.SuiteString);
-        stream.WriteByte(0x03);
-        stream.Write(gammaCofBytes);
-        stream.Seek(0, SeekOrigin.Begin);
-        return hasher.ComputeHash(stream);
-    }
-
-    private IECScalar Rfc6979Nonce(ECKeyPair keyPair, IECPoint hashPoint)
-    {
-        using var curve = new TCurve();
-        using var hasher = _hasherFactory.Create();
-        var roLen = (QBitsLength + 7) / 8;
-        var hBytes = curve.SerializePoint(hashPoint, true);
-
-        var hash = hasher.ComputeHash(hBytes);
-        var bh = Helpers.Bits2Bytes(hash, _config.EcParameters.N, roLen);
-
-        var nonce = curve.GetNonce(curve.DeserializeScalar(keyPair.PrivateKey), bh);
-        return curve.DeserializeScalar(nonce);
     }
 }

--- a/src/AElf.Cryptography/Exceptions/EcdhOperationException.cs
+++ b/src/AElf.Cryptography/Exceptions/EcdhOperationException.cs
@@ -1,10 +1,12 @@
 using System;
 
-namespace AElf.Cryptography.Exceptions;
-
-public class EcdhOperationException : Exception
+namespace AElf.Cryptography.Exceptions
 {
-    public EcdhOperationException(string message) : base(message)
+
+    public class EcdhOperationException : Exception
     {
+        public EcdhOperationException(string message) : base(message)
+        {
+        }
     }
 }

--- a/src/AElf.Cryptography/Exceptions/InvalidKeyPairException.cs
+++ b/src/AElf.Cryptography/Exceptions/InvalidKeyPairException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 
-namespace AElf.Cryptography.Exceptions;
-
-public class InvalidKeyPairException : Exception
+namespace AElf.Cryptography.Exceptions
 {
-    public InvalidKeyPairException(string message, Exception innerException) : base(message, innerException)
+
+    public class InvalidKeyPairException : Exception
     {
+        public InvalidKeyPairException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
     }
 }

--- a/src/AElf.Cryptography/Exceptions/InvalidPasswordException.cs
+++ b/src/AElf.Cryptography/Exceptions/InvalidPasswordException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 
-namespace AElf.Cryptography.Exceptions;
-
-public class InvalidPasswordException : Exception
+namespace AElf.Cryptography.Exceptions
 {
-    public InvalidPasswordException(string message, Exception innerException) : base(message, innerException)
+
+    public class InvalidPasswordException : Exception
     {
+        public InvalidPasswordException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
     }
 }

--- a/src/AElf.Cryptography/Exceptions/InvalidPrivateKeyException.cs
+++ b/src/AElf.Cryptography/Exceptions/InvalidPrivateKeyException.cs
@@ -1,10 +1,12 @@
 using System;
 
-namespace AElf.Cryptography.Exceptions;
-
-public class InvalidPrivateKeyException : Exception
+namespace AElf.Cryptography.Exceptions
 {
-    public InvalidPrivateKeyException(string message) : base(message)
+
+    public class InvalidPrivateKeyException : Exception
     {
+        public InvalidPrivateKeyException(string message) : base(message)
+        {
+        }
     }
 }

--- a/src/AElf.Cryptography/Exceptions/KeyStoreNotFoundException.cs
+++ b/src/AElf.Cryptography/Exceptions/KeyStoreNotFoundException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 
-namespace AElf.Cryptography.Exceptions;
-
-public class KeyStoreNotFoundException : Exception
+namespace AElf.Cryptography.Exceptions
 {
-    public KeyStoreNotFoundException(string message, Exception innerException) : base(message, innerException)
+
+    public class KeyStoreNotFoundException : Exception
     {
+        public KeyStoreNotFoundException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
     }
 }

--- a/src/AElf.Cryptography/Exceptions/PublicKeyOperationException.cs
+++ b/src/AElf.Cryptography/Exceptions/PublicKeyOperationException.cs
@@ -1,10 +1,12 @@
 using System;
 
-namespace AElf.Cryptography.Exceptions;
-
-public class PublicKeyOperationException : Exception
+namespace AElf.Cryptography.Exceptions
 {
-    public PublicKeyOperationException(string message) : base(message)
+
+    public class PublicKeyOperationException : Exception
     {
+        public PublicKeyOperationException(string message) : base(message)
+        {
+        }
     }
 }

--- a/src/AElf.Cryptography/Exceptions/SignatureOperationException.cs
+++ b/src/AElf.Cryptography/Exceptions/SignatureOperationException.cs
@@ -1,10 +1,12 @@
 using System;
 
-namespace AElf.Cryptography.Exceptions;
-
-public class SignatureOperationException : Exception
+namespace AElf.Cryptography.Exceptions
 {
-    public SignatureOperationException(string message) : base(message)
+
+    public class SignatureOperationException : Exception
     {
+        public SignatureOperationException(string message) : base(message)
+        {
+        }
     }
 }

--- a/src/AElf.Cryptography/IAElfAsymmetricCipherKeyPair.cs
+++ b/src/AElf.Cryptography/IAElfAsymmetricCipherKeyPair.cs
@@ -1,7 +1,9 @@
-namespace AElf.Cryptography;
-
-public interface IAElfAsymmetricCipherKeyPair
+namespace AElf.Cryptography
 {
-    byte[] PrivateKey { get; }
-    byte[] PublicKey { get; }
+
+    public interface IAElfAsymmetricCipherKeyPair
+    {
+        byte[] PrivateKey { get; }
+        byte[] PublicKey { get; }
+    }
 }

--- a/src/AElf.Cryptography/SecretSharing/SecretSharingConsts.cs
+++ b/src/AElf.Cryptography/SecretSharing/SecretSharingConsts.cs
@@ -1,9 +1,11 @@
 using System.Numerics;
 
-namespace AElf.Cryptography.SecretSharing;
-
-public static class SecretSharingConsts
+namespace AElf.Cryptography.SecretSharing
 {
-    public static readonly uint MaxBits = 1024;
-    public static readonly BigInteger FieldPrime = BigInteger.Pow(new BigInteger(2), 1025) - 1;
+
+    public static class SecretSharingConsts
+    {
+        public static readonly uint MaxBits = 1024;
+        public static readonly BigInteger FieldPrime = BigInteger.Pow(new BigInteger(2), 1025) - 1;
+    }
 }

--- a/src/AElf.Cryptography/SecretSharing/SecretSharingExtensions.cs
+++ b/src/AElf.Cryptography/SecretSharing/SecretSharingExtensions.cs
@@ -3,41 +3,43 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 
-namespace AElf.Cryptography.SecretSharing;
-
-public static class SecretSharingExtensions
+namespace AElf.Cryptography.SecretSharing
 {
-    public static BigInteger ToBigInteger(this byte[] bytes)
+
+    public static class SecretSharingExtensions
     {
-        var tempBytes = new byte[bytes.Length + 1];
-        Array.Copy(bytes.Reverse().ToArray(), 0, tempBytes, 1, bytes.Length);
-        return new BigInteger(tempBytes);
-    }
+        public static BigInteger ToBigInteger(this byte[] bytes)
+        {
+            var tempBytes = new byte[bytes.Length + 1];
+            Array.Copy(bytes.Reverse().ToArray(), 0, tempBytes, 1, bytes.Length);
+            return new BigInteger(tempBytes);
+        }
 
-    public static byte[] ToBytesArray(this BigInteger integer)
-    {
-        var tempBytes = integer.ToByteArray().Reverse().ToArray();
-        var result = new byte[tempBytes.Length - 1];
-        Array.Copy(tempBytes, 0, result, 0, result.Length);
+        public static byte[] ToBytesArray(this BigInteger integer)
+        {
+            var tempBytes = integer.ToByteArray().Reverse().ToArray();
+            var result = new byte[tempBytes.Length - 1];
+            Array.Copy(tempBytes, 0, result, 0, result.Length);
 
-        return result;
-    }
+            return result;
+        }
 
-    public static string ConvertToString(this BigInteger integer)
-    {
-        var bytes = integer.ToByteArray();
-        var chars = Encoding.UTF8.GetChars(bytes);
-        var size = 0;
-        for (; size < chars.Length; ++size)
-            if (chars[size] == '\0')
-                break;
+        public static string ConvertToString(this BigInteger integer)
+        {
+            var bytes = integer.ToByteArray();
+            var chars = Encoding.UTF8.GetChars(bytes);
+            var size = 0;
+            for (; size < chars.Length; ++size)
+                if (chars[size] == '\0')
+                    break;
 
-        return new string(chars, 0, size);
-    }
+            return new string(chars, 0, size);
+        }
 
-    public static BigInteger Abs(this BigInteger integer)
-    {
-        return (integer % SecretSharingConsts.FieldPrime + SecretSharingConsts.FieldPrime) %
-               SecretSharingConsts.FieldPrime;
+        public static BigInteger Abs(this BigInteger integer)
+        {
+            return (integer % SecretSharingConsts.FieldPrime + SecretSharingConsts.FieldPrime) %
+                   SecretSharingConsts.FieldPrime;
+        }
     }
 }

--- a/src/AElf.Cryptography/SecretSharing/SecretSharingHelper.cs
+++ b/src/AElf.Cryptography/SecretSharing/SecretSharingHelper.cs
@@ -3,104 +3,106 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 
-namespace AElf.Cryptography.SecretSharing;
-
-/// <summary>
-///     Implementation of Shamir's Secret Sharing: https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing
-/// </summary>
-public static class SecretSharingHelper
+namespace AElf.Cryptography.SecretSharing
 {
-    public static List<byte[]> EncodeSecret(byte[] secretMessage, int threshold, int totalParts)
-    {
-        // Polynomial construction.
-        var coefficients = new BigInteger[threshold];
-        // Set p(0) = secret message.
-        coefficients[0] = secretMessage.ToBigInteger();
-        for (var i = 1; i < threshold; i++)
-        {
-            var foo = new byte[32];
-            Array.Copy(HashHelper.ComputeFrom(Guid.NewGuid().ToByteArray()).ToArray(), foo, 32);
-            coefficients[i] = BigInteger.Abs(new BigInteger(foo));
-        }
 
-        var result = new List<byte[]>();
-        for (var i = 1; i < totalParts + 1; i++)
+    /// <summary>
+    ///     Implementation of Shamir's Secret Sharing: https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing
+    /// </summary>
+    public static class SecretSharingHelper
+    {
+        public static List<byte[]> EncodeSecret(byte[] secretMessage, int threshold, int totalParts)
         {
-            var secretBigInteger = coefficients[0];
-            for (var j = 1; j < threshold; j++)
+            // Polynomial construction.
+            var coefficients = new BigInteger[threshold];
+            // Set p(0) = secret message.
+            coefficients[0] = secretMessage.ToBigInteger();
+            for (var i = 1; i < threshold; i++)
             {
-                secretBigInteger += coefficients[j] * BigInteger.Pow(new BigInteger(i), j);
-                secretBigInteger %= SecretSharingConsts.FieldPrime;
+                var foo = new byte[32];
+                Array.Copy(HashHelper.ComputeFrom(Guid.NewGuid().ToByteArray()).ToArray(), foo, 32);
+                coefficients[i] = BigInteger.Abs(new BigInteger(foo));
             }
 
-            result.Add(secretBigInteger.ToByteArray());
-        }
-
-        return result;
-    }
-
-    // The shared parts must be sent in order.
-    public static byte[] DecodeSecret(List<byte[]> sharedParts, List<int> orders, int threshold)
-    {
-        var result = BigInteger.Zero;
-
-        for (var i = 0; i < threshold; i++)
-        {
-            var numerator = new BigInteger(sharedParts[i]);
-            var denominator = BigInteger.One;
-            for (var j = 0; j < threshold; j++)
+            var result = new List<byte[]>();
+            for (var i = 1; i < totalParts + 1; i++)
             {
-                if (i == j) continue;
+                var secretBigInteger = coefficients[0];
+                for (var j = 1; j < threshold; j++)
+                {
+                    secretBigInteger += coefficients[j] * BigInteger.Pow(new BigInteger(i), j);
+                    secretBigInteger %= SecretSharingConsts.FieldPrime;
+                }
 
-                (numerator, denominator) =
-                    MultiplyRational(numerator, denominator, orders[j], orders[j] - orders[i]);
+                result.Add(secretBigInteger.ToByteArray());
             }
 
-            result += RationalToWhole(numerator, denominator);
-            result %= SecretSharingConsts.FieldPrime;
+            return result;
         }
 
-        return result.ToBytesArray();
-    }
-
-    private static BigInteger RationalToWhole(BigInteger numerator, BigInteger denominator)
-    {
-        return numerator * Inverse(denominator) % SecretSharingConsts.FieldPrime;
-    }
-
-    private static BigInteger GetGreatestCommonDivisor(BigInteger integer1, BigInteger integer2)
-    {
-        while (true)
+        // The shared parts must be sent in order.
+        public static byte[] DecodeSecret(List<byte[]> sharedParts, List<int> orders, int threshold)
         {
-            if (integer2 == 0) return integer1;
-            var integer3 = integer1;
-            integer1 = integer2;
-            integer2 = integer3 % integer2;
+            var result = BigInteger.Zero;
+
+            for (var i = 0; i < threshold; i++)
+            {
+                var numerator = new BigInteger(sharedParts[i]);
+                var denominator = BigInteger.One;
+                for (var j = 0; j < threshold; j++)
+                {
+                    if (i == j) continue;
+
+                    (numerator, denominator) =
+                        MultiplyRational(numerator, denominator, orders[j], orders[j] - orders[i]);
+                }
+
+                result += RationalToWhole(numerator, denominator);
+                result %= SecretSharingConsts.FieldPrime;
+            }
+
+            return result.ToBytesArray();
         }
-    }
 
-    private static (BigInteger gcd, BigInteger invA, BigInteger invB) GetGreatestCommonDivisor2(BigInteger integer1,
-        BigInteger integer2)
-    {
-        if (integer2 == 0) return (integer1, 1, 0);
+        private static BigInteger RationalToWhole(BigInteger numerator, BigInteger denominator)
+        {
+            return numerator * Inverse(denominator) % SecretSharingConsts.FieldPrime;
+        }
 
-        var div = BigInteger.DivRem(integer1, integer2, out var rem);
-        var (g, iA, iB) = GetGreatestCommonDivisor2(integer2, rem);
-        return (g, iB, iA - iB * div);
-    }
+        private static BigInteger GetGreatestCommonDivisor(BigInteger integer1, BigInteger integer2)
+        {
+            while (true)
+            {
+                if (integer2 == 0) return integer1;
+                var integer3 = integer1;
+                integer1 = integer2;
+                integer2 = integer3 % integer2;
+            }
+        }
 
-    private static BigInteger Inverse(BigInteger integer)
-    {
-        return GetGreatestCommonDivisor2(SecretSharingConsts.FieldPrime, integer).invB.Abs();
-    }
+        private static (BigInteger gcd, BigInteger invA, BigInteger invB) GetGreatestCommonDivisor2(BigInteger integer1,
+            BigInteger integer2)
+        {
+            if (integer2 == 0) return (integer1, 1, 0);
 
-    private static (BigInteger numerator, BigInteger denominator) MultiplyRational(
-        BigInteger numeratorLhs, BigInteger denominatorLhs,
-        BigInteger numeratorRhs, BigInteger denominatorRhs)
-    {
-        var numerator = numeratorLhs * numeratorRhs % SecretSharingConsts.FieldPrime;
-        var denominator = denominatorLhs * denominatorRhs % SecretSharingConsts.FieldPrime;
-        var gcd = GetGreatestCommonDivisor(numerator, denominator);
-        return (numerator / gcd, denominator / gcd);
+            var div = BigInteger.DivRem(integer1, integer2, out var rem);
+            var (g, iA, iB) = GetGreatestCommonDivisor2(integer2, rem);
+            return (g, iB, iA - iB * div);
+        }
+
+        private static BigInteger Inverse(BigInteger integer)
+        {
+            return GetGreatestCommonDivisor2(SecretSharingConsts.FieldPrime, integer).invB.Abs();
+        }
+
+        private static (BigInteger numerator, BigInteger denominator) MultiplyRational(
+            BigInteger numeratorLhs, BigInteger denominatorLhs,
+            BigInteger numeratorRhs, BigInteger denominatorRhs)
+        {
+            var numerator = numeratorLhs * numeratorRhs % SecretSharingConsts.FieldPrime;
+            var denominator = denominatorLhs * denominatorRhs % SecretSharingConsts.FieldPrime;
+            var gcd = GetGreatestCommonDivisor(numerator, denominator);
+            return (numerator / gcd, denominator / gcd);
+        }
     }
 }

--- a/src/AElf.Types/AElf.Types.csproj
+++ b/src/AElf.Types/AElf.Types.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props"/>
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <RootNamespace>AElf</RootNamespace>
         <PackageId>AElf.Types</PackageId>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/AElf.Types/AElfConstants.cs
+++ b/src/AElf.Types/AElfConstants.cs
@@ -1,8 +1,10 @@
-namespace AElf;
-
-public static class AElfConstants
+namespace AElf
 {
-    public const long GenesisBlockHeight = 1;
-    public const int HashByteArrayLength = 32;
-    public const int AddressHashLength = 32;
+
+    public static class AElfConstants
+    {
+        public const long GenesisBlockHeight = 1;
+        public const int HashByteArrayLength = 32;
+        public const int AddressHashLength = 32;
+    }
 }

--- a/src/AElf.Types/Base58.cs
+++ b/src/AElf.Types/Base58.cs
@@ -5,169 +5,171 @@ using System.Numerics;
 using System.Security.Cryptography;
 using Google.Protobuf;
 
-namespace AElf;
-
-/// <summary>
-///     From https://github.com/adamcaudill/Base58Check, for NOT dotnet core version
-///     Base58Check Encoding / Decoding (Bitcoin-style)
-/// </summary>
-/// <remarks>
-///     See here for more details: https://en.bitcoin.it/wiki/Base58Check_encoding
-/// </remarks>
-public static class Base58CheckEncoding
+namespace AElf
 {
-    private const int CheckSumSize = 4;
-    private const string Digits = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    private static readonly HashSet<char> DigitsHash = new(Digits.ToCharArray());
 
     /// <summary>
-    ///     Encodes data with a 4-byte checksum
+    ///     From https://github.com/adamcaudill/Base58Check, for NOT dotnet core version
+    ///     Base58Check Encoding / Decoding (Bitcoin-style)
     /// </summary>
-    /// <param name="data">Data to be encoded</param>
-    /// <returns></returns>
-    public static string Encode(byte[] data)
+    /// <remarks>
+    ///     See here for more details: https://en.bitcoin.it/wiki/Base58Check_encoding
+    /// </remarks>
+    public static class Base58CheckEncoding
     {
-        return EncodePlain(_AddCheckSum(data));
-    }
+        private const int CheckSumSize = 4;
+        private const string Digits = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+        private static readonly HashSet<char> DigitsHash = new HashSet<char>(Digits.ToCharArray());
 
-    /// <summary>
-    ///     Encodes data in plain Base58, without any checksum.
-    /// </summary>
-    /// <param name="data">The data to be encoded</param>
-    /// <returns></returns>
-    public static string EncodePlain(byte[] data)
-    {
-        // Decode byte[] to BigInteger
-        var intData = data.Aggregate<byte, BigInteger>(0, (current, t) => current * 256 + t);
-
-        // Encode BigInteger to Base58 string
-        var result = string.Empty;
-        while (intData > 0)
+        /// <summary>
+        ///     Encodes data with a 4-byte checksum
+        /// </summary>
+        /// <param name="data">Data to be encoded</param>
+        /// <returns></returns>
+        public static string Encode(byte[] data)
         {
-            var remainder = (int)(intData % 58);
-            intData /= 58;
-            result = Digits[remainder] + result;
+            return EncodePlain(_AddCheckSum(data));
         }
 
-        // Append `1` for each leading 0 byte
-        for (var i = 0; i < data.Length && data[i] == 0; i++) result = '1' + result;
-
-        return result;
-    }
-
-    /// <summary>
-    ///     Encodes data in plain Base58, without any checksum.
-    /// </summary>
-    /// <param name="data">The data to be encoded</param>
-    /// <returns></returns>
-    public static string EncodePlain(ByteString data)
-    {
-        // Decode byte[] to BigInteger
-        var intData = data.Aggregate<byte, BigInteger>(0, (current, t) => current * 256 + t);
-
-        // Encode BigInteger to Base58 string
-        var result = string.Empty;
-        while (intData > 0)
+        /// <summary>
+        ///     Encodes data in plain Base58, without any checksum.
+        /// </summary>
+        /// <param name="data">The data to be encoded</param>
+        /// <returns></returns>
+        public static string EncodePlain(byte[] data)
         {
-            var remainder = (int)(intData % 58);
-            intData /= 58;
-            result = Digits[remainder] + result;
+            // Decode byte[] to BigInteger
+            var intData = data.Aggregate<byte, BigInteger>(0, (current, t) => current * 256 + t);
+
+            // Encode BigInteger to Base58 string
+            var result = string.Empty;
+            while (intData > 0)
+            {
+                var remainder = (int)(intData % 58);
+                intData /= 58;
+                result = Digits[remainder] + result;
+            }
+
+            // Append `1` for each leading 0 byte
+            for (var i = 0; i < data.Length && data[i] == 0; i++) result = '1' + result;
+
+            return result;
         }
 
-        // Append `1` for each leading 0 byte
-        for (var i = 0; i < data.Length && data[i] == 0; i++) result = '1' + result;
-
-        return result;
-    }
-
-
-    /// <summary>
-    ///     Decodes data in Base58Check format (with 4 byte checksum)
-    /// </summary>
-    /// <param name="data">Data to be decoded</param>
-    /// <returns>Returns decoded data if valid; throws FormatException if invalid</returns>
-    public static byte[] Decode(string data)
-    {
-        var dataWithCheckSum = DecodePlain(data);
-        var dataWithoutCheckSum = _VerifyAndRemoveCheckSum(dataWithCheckSum);
-
-        if (dataWithoutCheckSum == null) throw new FormatException("Base58 checksum is invalid");
-
-        return dataWithoutCheckSum;
-    }
-
-    /// <summary>
-    ///     Decodes data in plain Base58, without any checksum.
-    /// </summary>
-    /// <param name="data">Data to be decoded</param>
-    /// <returns>Returns decoded data if valid; throws FormatException if invalid</returns>
-    public static byte[] DecodePlain(string data)
-    {
-        // Decode Base58 string to BigInteger 
-        BigInteger intData = 0;
-        for (var i = 0; i < data.Length; i++)
+        /// <summary>
+        ///     Encodes data in plain Base58, without any checksum.
+        /// </summary>
+        /// <param name="data">The data to be encoded</param>
+        /// <returns></returns>
+        public static string EncodePlain(ByteString data)
         {
-            var digit = Digits.IndexOf(data[i]); //Slow
+            // Decode byte[] to BigInteger
+            var intData = data.Aggregate<byte, BigInteger>(0, (current, t) => current * 256 + t);
 
-            if (digit < 0) throw new FormatException($"Invalid Base58 character `{data[i]}` at position {i}");
+            // Encode BigInteger to Base58 string
+            var result = string.Empty;
+            while (intData > 0)
+            {
+                var remainder = (int)(intData % 58);
+                intData /= 58;
+                result = Digits[remainder] + result;
+            }
 
-            intData = intData * 58 + digit;
+            // Append `1` for each leading 0 byte
+            for (var i = 0; i < data.Length && data[i] == 0; i++) result = '1' + result;
+
+            return result;
         }
 
-        // Encode BigInteger to byte[]
-        // Leading zero bytes get encoded as leading `1` characters
-        var leadingZeroCount = data.TakeWhile(c => c == '1').Count();
-        var leadingZeros = Enumerable.Repeat((byte)0, leadingZeroCount);
-        var bytesWithoutLeadingZeros =
-            intData.ToByteArray()
-                .Reverse() // to big endian
-                .SkipWhile(b => b == 0); //strip sign byte
-        var result = leadingZeros.Concat(bytesWithoutLeadingZeros).ToArray();
 
-        return result;
-    }
+        /// <summary>
+        ///     Decodes data in Base58Check format (with 4 byte checksum)
+        /// </summary>
+        /// <param name="data">Data to be decoded</param>
+        /// <returns>Returns decoded data if valid; throws FormatException if invalid</returns>
+        public static byte[] Decode(string data)
+        {
+            var dataWithCheckSum = DecodePlain(data);
+            var dataWithoutCheckSum = _VerifyAndRemoveCheckSum(dataWithCheckSum);
 
-    public static bool Verify(string data)
-    {
-        for (var i = 0; i < data.Length; i++)
-            if (!DigitsHash.Contains(data[i]))
+            if (dataWithoutCheckSum == null) throw new FormatException("Base58 checksum is invalid");
+
+            return dataWithoutCheckSum;
+        }
+
+        /// <summary>
+        ///     Decodes data in plain Base58, without any checksum.
+        /// </summary>
+        /// <param name="data">Data to be decoded</param>
+        /// <returns>Returns decoded data if valid; throws FormatException if invalid</returns>
+        public static byte[] DecodePlain(string data)
+        {
+            // Decode Base58 string to BigInteger 
+            BigInteger intData = 0;
+            for (var i = 0; i < data.Length; i++)
+            {
+                var digit = Digits.IndexOf(data[i]); //Slow
+
+                if (digit < 0) throw new FormatException($"Invalid Base58 character `{data[i]}` at position {i}");
+
+                intData = intData * 58 + digit;
+            }
+
+            // Encode BigInteger to byte[]
+            // Leading zero bytes get encoded as leading `1` characters
+            var leadingZeroCount = data.TakeWhile(c => c == '1').Count();
+            var leadingZeros = Enumerable.Repeat((byte)0, leadingZeroCount);
+            var bytesWithoutLeadingZeros =
+                intData.ToByteArray()
+                    .Reverse() // to big endian
+                    .SkipWhile(b => b == 0); //strip sign byte
+            var result = leadingZeros.Concat(bytesWithoutLeadingZeros).ToArray();
+
+            return result;
+        }
+
+        public static bool Verify(string data)
+        {
+            for (var i = 0; i < data.Length; i++)
+                if (!DigitsHash.Contains(data[i]))
+                    return false;
+
+            var dataWithCheckSum = DecodePlain(data);
+            var dataWithoutCheckSum = _VerifyAndRemoveCheckSum(dataWithCheckSum);
+            if (dataWithoutCheckSum == null)
                 return false;
-
-        var dataWithCheckSum = DecodePlain(data);
-        var dataWithoutCheckSum = _VerifyAndRemoveCheckSum(dataWithCheckSum);
-        if (dataWithoutCheckSum == null)
-            return false;
-        return true;
-    }
-
-    private static byte[] _AddCheckSum(byte[] data)
-    {
-        var checkSum = _GetCheckSum(data);
-        var dataWithCheckSum = ByteArrayHelper.ConcatArrays(data, checkSum);
-
-        return dataWithCheckSum;
-    }
-
-    //Returns null if the checksum is invalid
-    private static byte[] _VerifyAndRemoveCheckSum(byte[] data)
-    {
-        var result = ByteArrayHelper.SubArray(data, 0, data.Length - CheckSumSize);
-        var givenCheckSum = ByteArrayHelper.SubArray(data, data.Length - CheckSumSize);
-        var correctCheckSum = _GetCheckSum(result);
-
-        return givenCheckSum.SequenceEqual(correctCheckSum) ? result : null;
-    }
-
-    private static byte[] _GetCheckSum(byte[] data)
-    {
-        var result = new byte[CheckSumSize];
-        using (var sha256 = SHA256.Create())
-        {
-            var hash1 = sha256.ComputeHash(data);
-            var hash2 = sha256.ComputeHash(hash1);
-            Buffer.BlockCopy(hash2, 0, result, 0, result.Length);
+            return true;
         }
 
-        return result;
+        private static byte[] _AddCheckSum(byte[] data)
+        {
+            var checkSum = _GetCheckSum(data);
+            var dataWithCheckSum = ByteArrayHelper.ConcatArrays(data, checkSum);
+
+            return dataWithCheckSum;
+        }
+
+        //Returns null if the checksum is invalid
+        private static byte[] _VerifyAndRemoveCheckSum(byte[] data)
+        {
+            var result = ByteArrayHelper.SubArray(data, 0, data.Length - CheckSumSize);
+            var givenCheckSum = ByteArrayHelper.SubArray(data, data.Length - CheckSumSize);
+            var correctCheckSum = _GetCheckSum(result);
+
+            return givenCheckSum.SequenceEqual(correctCheckSum) ? result : null;
+        }
+
+        private static byte[] _GetCheckSum(byte[] data)
+        {
+            var result = new byte[CheckSumSize];
+            using (var sha256 = SHA256.Create())
+            {
+                var hash1 = sha256.ComputeHash(data);
+                var hash2 = sha256.ComputeHash(hash1);
+                Buffer.BlockCopy(hash2, 0, result, 0, result.Length);
+            }
+
+            return result;
+        }
     }
 }

--- a/src/AElf.Types/Extensions/ByteExtensions.cs
+++ b/src/AElf.Types/Extensions/ByteExtensions.cs
@@ -3,119 +3,121 @@ using System.Linq;
 using System.Security.Cryptography;
 using Google.Protobuf;
 
-namespace AElf;
-
-public static class ByteExtensions
+namespace AElf
 {
-    public static string ToPlainBase58(this byte[] value)
+
+    public static class ByteExtensions
     {
-        return Base58CheckEncoding.EncodePlain(value);
-    }
-
-    public static string ToPlainBase58(this ByteString value)
-    {
-        return Base58CheckEncoding.EncodePlain(value);
-    }
-
-    public static string ToHex(this byte[] bytes, bool withPrefix = false)
-    {
-        var offset = withPrefix ? 2 : 0;
-        var length = bytes.Length * 2 + offset;
-        var c = new char[length];
-
-        byte b;
-
-        if (withPrefix)
+        public static string ToPlainBase58(this byte[] value)
         {
-            c[0] = '0';
-            c[1] = 'x';
+            return Base58CheckEncoding.EncodePlain(value);
         }
 
-        for (int bx = 0, cx = offset; bx < bytes.Length; ++bx, ++cx)
+        public static string ToPlainBase58(this ByteString value)
         {
-            b = (byte)(bytes[bx] >> 4);
-            c[cx] = (char)(b > 9 ? b + 0x37 + 0x20 : b + 0x30);
-
-            b = (byte)(bytes[bx] & 0x0F);
-            c[++cx] = (char)(b > 9 ? b + 0x37 + 0x20 : b + 0x30);
+            return Base58CheckEncoding.EncodePlain(value);
         }
 
-        return new string(c);
-    }
-
-    public static int ToInt32(this byte[] bytes, bool bigEndian)
-    {
-        var needReverse = !bigEndian ^ BitConverter.IsLittleEndian;
-        return BitConverter.ToInt32(needReverse ? bytes.Reverse().ToArray() : bytes, 0);
-    }
-
-    public static long ToInt64(this byte[] bytes, bool bigEndian)
-    {
-        var needReverse = !bigEndian ^ BitConverter.IsLittleEndian;
-        return BitConverter.ToInt64(needReverse ? bytes.Reverse().ToArray() : bytes, 0);
-    }
-
-    /// <summary>
-    ///     Calculates the hash for a byte array.
-    /// </summary>
-    /// <param name="bytes"></param>
-    /// <returns></returns>
-    public static byte[] ComputeHash(this byte[] bytes)
-    {
-        using (var sha256 = SHA256.Create())
+        public static string ToHex(this byte[] bytes, bool withPrefix = false)
         {
-            return sha256.ComputeHash(bytes);
-        }
-    }
+            var offset = withPrefix ? 2 : 0;
+            var length = bytes.Length * 2 + offset;
+            var c = new char[length];
 
-    public static byte[] LeftPad(this byte[] bytes, int length)
-    {
-        if (length <= bytes.Length)
-            return bytes;
+            byte b;
 
-        var paddedBytes = new byte[length];
-        Buffer.BlockCopy(bytes, 0, paddedBytes, length - bytes.Length, bytes.Length);
-        return paddedBytes;
-    }
+            if (withPrefix)
+            {
+                c[0] = '0';
+                c[1] = 'x';
+            }
 
-    /// <summary>
-    ///     Find subarray in the source array.
-    /// </summary>
-    /// <param name="array">Source array to search for needle.</param>
-    /// <param name="needle">Needle we are searching for.</param>
-    /// <param name="startIndex">Start index in source array.</param>
-    /// <param name="sourceLength">Number of bytes in source array, where the needle is searched for.</param>
-    /// <returns>Returns starting position of the needle if it was found or <b>-1</b> otherwise.</returns>
-    public static int Find(this byte[] array, byte[] needle, int startIndex = 0)
-    {
-        var needleLen = needle.Length;
-        var sourceLength = array.Length;
-        int index;
+            for (int bx = 0, cx = offset; bx < bytes.Length; ++bx, ++cx)
+            {
+                b = (byte)(bytes[bx] >> 4);
+                c[cx] = (char)(b > 9 ? b + 0x37 + 0x20 : b + 0x30);
 
-        while (sourceLength >= needleLen)
-        {
-            // find needle's starting element
-            index = Array.IndexOf(array, needle[0], startIndex, sourceLength - needleLen + 1);
+                b = (byte)(bytes[bx] & 0x0F);
+                c[++cx] = (char)(b > 9 ? b + 0x37 + 0x20 : b + 0x30);
+            }
 
-            // if we did not find even the first element of the needls, then the search is failed
-            if (index == -1)
-                return -1;
-
-            int i, p;
-            // check for needle
-            for (i = 0, p = index; i < needleLen; i++, p++)
-                if (array[p] != needle[i])
-                    break;
-
-            if (i == needleLen)
-                // needle was found
-                return index;
-
-            // continue to search for needle
-            sourceLength -= index - startIndex + 1;
-            startIndex = index + 1;
+            return new string(c);
         }
 
-        return -1;
+        public static int ToInt32(this byte[] bytes, bool bigEndian)
+        {
+            var needReverse = !bigEndian ^ BitConverter.IsLittleEndian;
+            return BitConverter.ToInt32(needReverse ? bytes.Reverse().ToArray() : bytes, 0);
+        }
+
+        public static long ToInt64(this byte[] bytes, bool bigEndian)
+        {
+            var needReverse = !bigEndian ^ BitConverter.IsLittleEndian;
+            return BitConverter.ToInt64(needReverse ? bytes.Reverse().ToArray() : bytes, 0);
+        }
+
+        /// <summary>
+        ///     Calculates the hash for a byte array.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static byte[] ComputeHash(this byte[] bytes)
+        {
+            using (var sha256 = SHA256.Create())
+            {
+                return sha256.ComputeHash(bytes);
+            }
+        }
+
+        public static byte[] LeftPad(this byte[] bytes, int length)
+        {
+            if (length <= bytes.Length)
+                return bytes;
+
+            var paddedBytes = new byte[length];
+            Buffer.BlockCopy(bytes, 0, paddedBytes, length - bytes.Length, bytes.Length);
+            return paddedBytes;
+        }
+
+        /// <summary>
+        ///     Find subarray in the source array.
+        /// </summary>
+        /// <param name="array">Source array to search for needle.</param>
+        /// <param name="needle">Needle we are searching for.</param>
+        /// <param name="startIndex">Start index in source array.</param>
+        /// <param name="sourceLength">Number of bytes in source array, where the needle is searched for.</param>
+        /// <returns>Returns starting position of the needle if it was found or <b>-1</b> otherwise.</returns>
+        public static int Find(this byte[] array, byte[] needle, int startIndex = 0)
+        {
+            var needleLen = needle.Length;
+            var sourceLength = array.Length;
+            int index;
+
+            while (sourceLength >= needleLen)
+            {
+                // find needle's starting element
+                index = Array.IndexOf(array, needle[0], startIndex, sourceLength - needleLen + 1);
+
+                // if we did not find even the first element of the needls, then the search is failed
+                if (index == -1)
+                    return -1;
+
+                int i, p;
+                // check for needle
+                for (i = 0, p = index; i < needleLen; i++, p++)
+                    if (array[p] != needle[i])
+                        break;
+
+                if (i == needleLen)
+                    // needle was found
+                    return index;
+
+                // continue to search for needle
+                sourceLength -= index - startIndex + 1;
+                startIndex = index + 1;
+            }
+
+            return -1;
+        }
     }
 }

--- a/src/AElf.Types/Extensions/ByteStringExtensions.cs
+++ b/src/AElf.Types/Extensions/ByteStringExtensions.cs
@@ -1,37 +1,39 @@
 using Google.Protobuf;
 
-namespace AElf;
-
-public static class ByteStringExtensions
+namespace AElf
 {
-    public static string ToHex(this ByteString bytes, bool withPrefix = false)
+
+    public static class ByteStringExtensions
     {
-        var offset = withPrefix ? 2 : 0;
-        var length = bytes.Length * 2 + offset;
-        var c = new char[length];
-
-        byte b;
-
-        if (withPrefix)
+        public static string ToHex(this ByteString bytes, bool withPrefix = false)
         {
-            c[0] = '0';
-            c[1] = 'x';
+            var offset = withPrefix ? 2 : 0;
+            var length = bytes.Length * 2 + offset;
+            var c = new char[length];
+
+            byte b;
+
+            if (withPrefix)
+            {
+                c[0] = '0';
+                c[1] = 'x';
+            }
+
+            for (int bx = 0, cx = offset; bx < bytes.Length; ++bx, ++cx)
+            {
+                b = (byte)(bytes[bx] >> 4);
+                c[cx] = (char)(b > 9 ? b + 0x37 + 0x20 : b + 0x30);
+
+                b = (byte)(bytes[bx] & 0x0F);
+                c[++cx] = (char)(b > 9 ? b + 0x37 + 0x20 : b + 0x30);
+            }
+
+            return new string(c);
         }
 
-        for (int bx = 0, cx = offset; bx < bytes.Length; ++bx, ++cx)
+        public static bool IsNullOrEmpty(this ByteString byteString)
         {
-            b = (byte)(bytes[bx] >> 4);
-            c[cx] = (char)(b > 9 ? b + 0x37 + 0x20 : b + 0x30);
-
-            b = (byte)(bytes[bx] & 0x0F);
-            c[++cx] = (char)(b > 9 ? b + 0x37 + 0x20 : b + 0x30);
+            return byteString == null || byteString.IsEmpty;
         }
-
-        return new string(c);
-    }
-
-    public static bool IsNullOrEmpty(this ByteString byteString)
-    {
-        return byteString == null || byteString.IsEmpty;
     }
 }

--- a/src/AElf.Types/Extensions/HexStringExtensions.cs
+++ b/src/AElf.Types/Extensions/HexStringExtensions.cs
@@ -1,13 +1,15 @@
 using System;
 using Google.Protobuf;
 
-namespace AElf;
-
-public static class HexStringExtensions
+namespace AElf
 {
-    [Obsolete("Use ByteStringHelper.FromHexString instead.")]
-    public static ByteString ToByteString(this string hexString)
+
+    public static class HexStringExtensions
     {
-        return ByteString.CopyFrom(ByteArrayHelper.HexStringToByteArray(hexString));
+        [Obsolete("Use ByteStringHelper.FromHexString instead.")]
+        public static ByteString ToByteString(this string hexString)
+        {
+            return ByteString.CopyFrom(ByteArrayHelper.HexStringToByteArray(hexString));
+        }
     }
 }

--- a/src/AElf.Types/Extensions/IMessageExtensions.cs
+++ b/src/AElf.Types/Extensions/IMessageExtensions.cs
@@ -1,12 +1,14 @@
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
-namespace AElf;
-
-public static class IMessageExtensions
+namespace AElf
 {
-    public static BytesValue ToBytesValue(this IMessage message)
+
+    public static class IMessageExtensions
     {
-        return new BytesValue { Value = message.ToByteString() };
+        public static BytesValue ToBytesValue(this IMessage message)
+        {
+            return new BytesValue { Value = message.ToByteString() };
+        }
     }
 }

--- a/src/AElf.Types/Extensions/MerklePathExtensions.cs
+++ b/src/AElf.Types/Extensions/MerklePathExtensions.cs
@@ -1,14 +1,16 @@
 using System.Linq;
 using AElf.Types;
 
-namespace AElf;
-
-public static class MerklePathExtensions
+namespace AElf
 {
-    public static Hash ComputeRootWithLeafNode(this MerklePath path, Hash leaf)
+
+    public static class MerklePathExtensions
     {
-        return path.MerklePathNodes.Aggregate(leaf, (current, node) => node.IsLeftChildNode
-            ? HashHelper.ConcatAndCompute(node.Hash, current)
-            : HashHelper.ConcatAndCompute(current, node.Hash));
+        public static Hash ComputeRootWithLeafNode(this MerklePath path, Hash leaf)
+        {
+            return path.MerklePathNodes.Aggregate(leaf, (current, node) => node.IsLeftChildNode
+                ? HashHelper.ConcatAndCompute(node.Hash, current)
+                : HashHelper.ConcatAndCompute(current, node.Hash));
+        }
     }
 }

--- a/src/AElf.Types/Extensions/NumericExtensions.cs
+++ b/src/AElf.Types/Extensions/NumericExtensions.cs
@@ -1,38 +1,40 @@
 using System;
 using System.Linq;
 
-namespace AElf;
-
-public static class NumericExtensions
+namespace AElf
 {
-    public static byte[] ToBytes(this long n, bool bigEndian = true)
-    {
-        var bytes = BitConverter.GetBytes(n);
-        return GetBytesWithEndian(bytes, bigEndian);
-    }
 
-    public static byte[] ToBytes(this ulong n, bool bigEndian = true)
+    public static class NumericExtensions
     {
-        var bytes = BitConverter.GetBytes(n);
-        return GetBytesWithEndian(bytes, bigEndian);
-    }
+        public static byte[] ToBytes(this long n, bool bigEndian = true)
+        {
+            var bytes = BitConverter.GetBytes(n);
+            return GetBytesWithEndian(bytes, bigEndian);
+        }
 
-    public static byte[] ToBytes(this int n, bool bigEndian = true)
-    {
-        var bytes = BitConverter.GetBytes(n);
-        return GetBytesWithEndian(bytes, bigEndian);
-    }
+        public static byte[] ToBytes(this ulong n, bool bigEndian = true)
+        {
+            var bytes = BitConverter.GetBytes(n);
+            return GetBytesWithEndian(bytes, bigEndian);
+        }
 
-    public static byte[] ToBytes(this uint n, bool bigEndian = true)
-    {
-        var bytes = BitConverter.GetBytes(n);
-        return GetBytesWithEndian(bytes, bigEndian);
-    }
+        public static byte[] ToBytes(this int n, bool bigEndian = true)
+        {
+            var bytes = BitConverter.GetBytes(n);
+            return GetBytesWithEndian(bytes, bigEndian);
+        }
 
-    private static byte[] GetBytesWithEndian(byte[] bytes, bool bigEndian)
-    {
-        if (bigEndian ^ BitConverter.IsLittleEndian)
-            return bytes;
-        return bytes.Reverse().ToArray();
+        public static byte[] ToBytes(this uint n, bool bigEndian = true)
+        {
+            var bytes = BitConverter.GetBytes(n);
+            return GetBytesWithEndian(bytes, bigEndian);
+        }
+
+        private static byte[] GetBytesWithEndian(byte[] bytes, bool bigEndian)
+        {
+            if (bigEndian ^ BitConverter.IsLittleEndian)
+                return bytes;
+            return bytes.Reverse().ToArray();
+        }
     }
 }

--- a/src/AElf.Types/Extensions/StateKeyExtensions.cs
+++ b/src/AElf.Types/Extensions/StateKeyExtensions.cs
@@ -1,22 +1,24 @@
 using System.Linq;
 using AElf.Types;
 
-namespace AElf;
-
-public static class StateKeyExtensions
+namespace AElf
 {
-    public static string ToStateKey(this StatePath statePath, Address address)
-    {
-        return new ScopedStatePath
-        {
-            Address = address,
-            Path = statePath
-        }.ToStateKey();
-    }
 
-    public static string ToStateKey(this ScopedStatePath scopedStatePath)
+    public static class StateKeyExtensions
     {
-        return string.Join("/",
-            new[] { scopedStatePath.Address.ToBase58() }.Concat(scopedStatePath.Path.Parts));
+        public static string ToStateKey(this StatePath statePath, Address address)
+        {
+            return new ScopedStatePath
+            {
+                Address = address,
+                Path = statePath
+            }.ToStateKey();
+        }
+
+        public static string ToStateKey(this ScopedStatePath scopedStatePath)
+        {
+            return string.Join("/",
+                new[] { scopedStatePath.Address.ToBase58() }.Concat(scopedStatePath.Path.Parts));
+        }
     }
 }

--- a/src/AElf.Types/Extensions/StringExtensions.cs
+++ b/src/AElf.Types/Extensions/StringExtensions.cs
@@ -1,11 +1,13 @@
 ﻿using System.Text;
 
-namespace AElf;
-
-public static class StringExtensions
+namespace AElf
 {
-    public static byte[] GetBytes(this string value)
+
+    public static class StringExtensions
     {
-        return Encoding.UTF8.GetBytes(value);
+        public static byte[] GetBytes(this string value)
+        {
+            return Encoding.UTF8.GetBytes(value);
+        }
     }
 }

--- a/src/AElf.Types/Helper/AddressHelper.cs
+++ b/src/AElf.Types/Helper/AddressHelper.cs
@@ -1,11 +1,13 @@
-namespace AElf;
-
-public static class AddressHelper
+namespace AElf
 {
-    public static bool VerifyFormattedAddress(string formattedAddress)
+
+    public static class AddressHelper
     {
-        if (string.IsNullOrEmpty(formattedAddress))
-            return false;
-        return Base58CheckEncoding.Verify(formattedAddress);
+        public static bool VerifyFormattedAddress(string formattedAddress)
+        {
+            if (string.IsNullOrEmpty(formattedAddress))
+                return false;
+            return Base58CheckEncoding.Verify(formattedAddress);
+        }
     }
 }

--- a/src/AElf.Types/Helper/BlockHelper.cs
+++ b/src/AElf.Types/Helper/BlockHelper.cs
@@ -2,13 +2,15 @@ using System.Linq;
 using AElf.Types;
 using Google.Protobuf;
 
-namespace AElf;
-
-public static class BlockHelper
+namespace AElf
 {
-    public static ByteString GetRefBlockPrefix(Hash blockHash)
+
+    public static class BlockHelper
     {
-        var refBlockPrefix = ByteString.CopyFrom(blockHash.Value.Take(4).ToArray());
-        return refBlockPrefix;
+        public static ByteString GetRefBlockPrefix(Hash blockHash)
+        {
+            var refBlockPrefix = ByteString.CopyFrom(blockHash.Value.Take(4).ToArray());
+            return refBlockPrefix;
+        }
     }
 }

--- a/src/AElf.Types/Helper/ByteArrayHelper.cs
+++ b/src/AElf.Types/Helper/ByteArrayHelper.cs
@@ -1,59 +1,61 @@
 ﻿using System;
 
-namespace AElf;
-
-public static class ByteArrayHelper
+namespace AElf
 {
-    public static byte[] HexStringToByteArray(string hex)
+
+    public static class ByteArrayHelper
     {
-        if (hex.Length >= 2 && hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X'))
-            hex = hex.Substring(2);
-        var numberChars = hex.Length;
-        var bytes = new byte[numberChars / 2];
+        public static byte[] HexStringToByteArray(string hex)
+        {
+            if (hex.Length >= 2 && hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X'))
+                hex = hex.Substring(2);
+            var numberChars = hex.Length;
+            var bytes = new byte[numberChars / 2];
 
-        for (var i = 0; i < numberChars; i += 2)
-            bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+            for (var i = 0; i < numberChars; i += 2)
+                bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
 
-        return bytes;
-    }
+            return bytes;
+        }
 
-    public static bool BytesEqual(this byte[] b1, byte[] b2)
-    {
-        if (b1 == b2)
-            return true;
+        public static bool BytesEqual(this byte[] b1, byte[] b2)
+        {
+            if (b1 == b2)
+                return true;
 
-        if (b1 == null || b2 == null)
-            return false;
-
-        if (b1.Length != b2.Length)
-            return false;
-
-        for (var i = 0; i < b1.Length; i++)
-            if (b1[i] != b2[i])
+            if (b1 == null || b2 == null)
                 return false;
 
-        return true;
-    }
+            if (b1.Length != b2.Length)
+                return false;
 
-    public static byte[] ConcatArrays(byte[] arr1, byte[] arr2)
-    {
-        var result = new byte[arr1.Length + arr2.Length];
-        Buffer.BlockCopy(arr1, 0, result, 0, arr1.Length);
-        Buffer.BlockCopy(arr2, 0, result, arr1.Length, arr2.Length);
+            for (var i = 0; i < b1.Length; i++)
+                if (b1[i] != b2[i])
+                    return false;
 
-        return result;
-    }
+            return true;
+        }
 
-    public static byte[] SubArray(byte[] arr, int start, int length)
-    {
-        var result = new byte[length];
-        Buffer.BlockCopy(arr, start, result, 0, length);
+        public static byte[] ConcatArrays(byte[] arr1, byte[] arr2)
+        {
+            var result = new byte[arr1.Length + arr2.Length];
+            Buffer.BlockCopy(arr1, 0, result, 0, arr1.Length);
+            Buffer.BlockCopy(arr2, 0, result, arr1.Length, arr2.Length);
 
-        return result;
-    }
+            return result;
+        }
 
-    public static byte[] SubArray(byte[] arr, int start)
-    {
-        return SubArray(arr, start, arr.Length - start);
+        public static byte[] SubArray(byte[] arr, int start, int length)
+        {
+            var result = new byte[length];
+            Buffer.BlockCopy(arr, start, result, 0, length);
+
+            return result;
+        }
+
+        public static byte[] SubArray(byte[] arr, int start)
+        {
+            return SubArray(arr, start, arr.Length - start);
+        }
     }
 }

--- a/src/AElf.Types/Helper/ByteStringHelper.cs
+++ b/src/AElf.Types/Helper/ByteStringHelper.cs
@@ -1,24 +1,26 @@
 using System;
 using Google.Protobuf;
 
-namespace AElf;
-
-public static class ByteStringHelper
+namespace AElf
 {
-    public static int Compare(ByteString xValue, ByteString yValue)
-    {
-        for (var i = 0; i < Math.Min(xValue.Length, yValue.Length); i++)
-        {
-            if (xValue[i] > yValue[i]) return 1;
 
-            if (xValue[i] < yValue[i]) return -1;
+    public static class ByteStringHelper
+    {
+        public static int Compare(ByteString xValue, ByteString yValue)
+        {
+            for (var i = 0; i < Math.Min(xValue.Length, yValue.Length); i++)
+            {
+                if (xValue[i] > yValue[i]) return 1;
+
+                if (xValue[i] < yValue[i]) return -1;
+            }
+
+            return 0;
         }
 
-        return 0;
-    }
-
-    public static ByteString FromHexString(string hexString)
-    {
-        return ByteString.CopyFrom(ByteArrayHelper.HexStringToByteArray(hexString));
+        public static ByteString FromHexString(string hexString)
+        {
+            return ByteString.CopyFrom(ByteArrayHelper.HexStringToByteArray(hexString));
+        }
     }
 }

--- a/src/AElf.Types/Helper/ChainHelper.cs
+++ b/src/AElf.Types/Helper/ChainHelper.cs
@@ -1,42 +1,44 @@
 ﻿using System;
 using System.Linq;
 
-namespace AElf;
-
-public static class ChainHelper
+namespace AElf
 {
-    public static int GetChainId(long serialNumber)
+
+    public static class ChainHelper
     {
-        // For 4 base58 chars use following range (2111 ~ zzzz):
-        // Max: 57*58*58*58+57*58*58+57*58+57 = 11316496 (zzzz)
-        // Min: 1*58*58*58+0*58*58+0*58+0 = 195112 (2111)
-        var validNUmber = (uint)serialNumber.GetHashCode() % 11316496;
-        if (validNUmber < 195112)
-            validNUmber += 195112;
+        public static int GetChainId(long serialNumber)
+        {
+            // For 4 base58 chars use following range (2111 ~ zzzz):
+            // Max: 57*58*58*58+57*58*58+57*58+57 = 11316496 (zzzz)
+            // Min: 1*58*58*58+0*58*58+0*58+0 = 195112 (2111)
+            var validNUmber = (uint)serialNumber.GetHashCode() % 11316496;
+            if (validNUmber < 195112)
+                validNUmber += 195112;
 
-        var validNUmberBytes = validNUmber.ToBytes().Skip(1).ToArray();
+            var validNUmberBytes = validNUmber.ToBytes().Skip(1).ToArray();
 
-        // Use BigInteger(BigEndian) format (bytes size = 3)
-        Array.Resize(ref validNUmberBytes, 4);
+            // Use BigInteger(BigEndian) format (bytes size = 3)
+            Array.Resize(ref validNUmberBytes, 4);
 
-        return validNUmberBytes.ToInt32(false);
-    }
+            return validNUmberBytes.ToInt32(false);
+        }
 
-    public static string ConvertChainIdToBase58(int chainId)
-    {
-        // Default chain id is 4 base58 chars, bytes size is 3
-        var bytes = chainId.ToBytes(false);
-        Array.Resize(ref bytes, 3);
-        return bytes.ToPlainBase58();
-    }
+        public static string ConvertChainIdToBase58(int chainId)
+        {
+            // Default chain id is 4 base58 chars, bytes size is 3
+            var bytes = chainId.ToBytes(false);
+            Array.Resize(ref bytes, 3);
+            return bytes.ToPlainBase58();
+        }
 
-    public static int ConvertBase58ToChainId(string base58String)
-    {
-        // Use int type to save chain id (4 base58 chars, default is 3 bytes)
-        var bytes = Base58CheckEncoding.DecodePlain(base58String);
-        if (bytes.Length < 4)
-            Array.Resize(ref bytes, 4);
+        public static int ConvertBase58ToChainId(string base58String)
+        {
+            // Use int type to save chain id (4 base58 chars, default is 3 bytes)
+            var bytes = Base58CheckEncoding.DecodePlain(base58String);
+            if (bytes.Length < 4)
+                Array.Resize(ref bytes, 4);
 
-        return bytes.ToInt32(false);
+            return bytes.ToInt32(false);
+        }
     }
 }

--- a/src/AElf.Types/Helper/HashHelper.cs
+++ b/src/AElf.Types/Helper/HashHelper.cs
@@ -2,84 +2,86 @@ using System.Text;
 using AElf.Types;
 using Google.Protobuf;
 
-namespace AElf;
-
-public class HashHelper
+namespace AElf
 {
-    /// <summary>
-    ///     Computes hash from a byte array.
-    /// </summary>
-    /// <param name="bytes"></param>
-    /// <returns></returns>
-    public static Hash ComputeFrom(byte[] bytes)
-    {
-        return Hash.LoadFromByteArray(bytes.ComputeHash());
-    }
 
-    /// <summary>
-    ///     Computes hash from a string encoded in UTF8.
-    /// </summary>
-    /// <param name="str"></param>
-    /// <returns></returns>
-    public static Hash ComputeFrom(string str)
+    public class HashHelper
     {
-        return ComputeFrom(Encoding.UTF8.GetBytes(str));
-    }
+        /// <summary>
+        ///     Computes hash from a byte array.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static Hash ComputeFrom(byte[] bytes)
+        {
+            return Hash.LoadFromByteArray(bytes.ComputeHash());
+        }
 
-    /// <summary>
-    ///     Computes hash from int32 value.
-    /// </summary>
-    /// <param name="intValue"></param>
-    /// <returns></returns>
-    public static Hash ComputeFrom(int intValue)
-    {
-        return ComputeFrom(intValue.ToBytes(false));
-    }
+        /// <summary>
+        ///     Computes hash from a string encoded in UTF8.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public static Hash ComputeFrom(string str)
+        {
+            return ComputeFrom(Encoding.UTF8.GetBytes(str));
+        }
 
-    /// <summary>
-    ///     Computes hash from int64 value.
-    /// </summary>
-    /// <param name="intValue"></param>
-    /// <returns></returns>
-    public static Hash ComputeFrom(long intValue)
-    {
-        return ComputeFrom(intValue.ToBytes(false));
-    }
+        /// <summary>
+        ///     Computes hash from int32 value.
+        /// </summary>
+        /// <param name="intValue"></param>
+        /// <returns></returns>
+        public static Hash ComputeFrom(int intValue)
+        {
+            return ComputeFrom(intValue.ToBytes(false));
+        }
 
-    /// <summary>
-    ///     Gets the hash from a Protobuf Message. Its serialized byte array is used for hash calculation.
-    /// </summary>
-    /// <param name="message"></param>
-    /// <returns></returns>
-    public static Hash ComputeFrom(IMessage message)
-    {
-        return ComputeFrom(message.ToByteArray());
-    }
+        /// <summary>
+        ///     Computes hash from int64 value.
+        /// </summary>
+        /// <param name="intValue"></param>
+        /// <returns></returns>
+        public static Hash ComputeFrom(long intValue)
+        {
+            return ComputeFrom(intValue.ToBytes(false));
+        }
 
-    /// <summary>
-    ///     Computes a new hash from two input hashes with bitwise xor operation.
-    /// </summary>
-    /// <param name="h1"></param>
-    /// <param name="h2"></param>
-    /// <returns></returns>
-    public static Hash XorAndCompute(Hash h1, Hash h2)
-    {
-        var newBytes = new byte[AElfConstants.HashByteArrayLength];
-        for (var i = 0; i < newBytes.Length; i++) newBytes[i] = (byte)(h1.Value[i] ^ h2.Value[i]);
+        /// <summary>
+        ///     Gets the hash from a Protobuf Message. Its serialized byte array is used for hash calculation.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public static Hash ComputeFrom(IMessage message)
+        {
+            return ComputeFrom(message.ToByteArray());
+        }
 
-        return ComputeFrom(newBytes);
-    }
+        /// <summary>
+        ///     Computes a new hash from two input hashes with bitwise xor operation.
+        /// </summary>
+        /// <param name="h1"></param>
+        /// <param name="h2"></param>
+        /// <returns></returns>
+        public static Hash XorAndCompute(Hash h1, Hash h2)
+        {
+            var newBytes = new byte[AElfConstants.HashByteArrayLength];
+            for (var i = 0; i < newBytes.Length; i++) newBytes[i] = (byte)(h1.Value[i] ^ h2.Value[i]);
 
-    public static Hash ConcatAndCompute(Hash hash1, Hash hash2)
-    {
-        var bytes = ByteArrayHelper.ConcatArrays(hash1.ToByteArray(), hash2.ToByteArray());
-        return ComputeFrom(bytes);
-    }
+            return ComputeFrom(newBytes);
+        }
 
-    public static Hash ConcatAndCompute(Hash hash1, Hash hash2, Hash hash3)
-    {
-        var bytes = ByteArrayHelper.ConcatArrays(
-            ByteArrayHelper.ConcatArrays(hash1.ToByteArray(), hash2.ToByteArray()), hash3.ToByteArray());
-        return ComputeFrom(bytes);
+        public static Hash ConcatAndCompute(Hash hash1, Hash hash2)
+        {
+            var bytes = ByteArrayHelper.ConcatArrays(hash1.ToByteArray(), hash2.ToByteArray());
+            return ComputeFrom(bytes);
+        }
+
+        public static Hash ConcatAndCompute(Hash hash1, Hash hash2, Hash hash3)
+        {
+            var bytes = ByteArrayHelper.ConcatArrays(
+                ByteArrayHelper.ConcatArrays(hash1.ToByteArray(), hash2.ToByteArray()), hash3.ToByteArray());
+            return ComputeFrom(bytes);
+        }
     }
 }

--- a/src/AElf.Types/Helper/SerializationHelper.cs
+++ b/src/AElf.Types/Helper/SerializationHelper.cs
@@ -4,111 +4,113 @@ using System.IO;
 using System.Text;
 using Google.Protobuf;
 
-namespace AElf;
-
-public static class SerializationHelper
+namespace AElf
 {
-    private static readonly Dictionary<Type, Action<CodedOutputStream, object>> _primitiveWriters =
-        new()
-        {
-            { typeof(bool), (stream, value) => stream.WriteBool((bool)value) },
-            { typeof(int), (stream, value) => stream.WriteSInt32((int)value) },
-            { typeof(uint), (stream, value) => stream.WriteUInt32((uint)value) },
-            { typeof(long), (stream, value) => stream.WriteSInt64((long)value) },
-            { typeof(ulong), (stream, value) => stream.WriteUInt64((ulong)value) },
-            { typeof(byte[]), (stream, value) => stream.WriteBytes(ByteString.CopyFrom((byte[])value)) }
-        };
 
-    private static readonly Dictionary<Type, Func<CodedInputStream, object>> _primitiveReaders =
-        new()
-        {
-            { typeof(bool), stream => stream.ReadBool() },
-            { typeof(int), stream => stream.ReadSInt32() },
-            { typeof(uint), stream => stream.ReadUInt32() },
-            { typeof(long), stream => stream.ReadSInt64() },
-            { typeof(ulong), stream => stream.ReadUInt64() },
-            { typeof(byte[]), stream => stream.ReadBytes().ToByteArray() }
-        };
-
-    private static Func<object, byte[]> GetPrimitiveSerializer(Type type)
+    public static class SerializationHelper
     {
-        if (_primitiveWriters.TryGetValue(type, out var writer))
-            return value =>
+        private static readonly Dictionary<Type, Action<CodedOutputStream, object>> _primitiveWriters =
+            new Dictionary<Type, Action<CodedOutputStream, object>>()
             {
-                using (var mm = new MemoryStream())
-                using (var cos = new CodedOutputStream(mm))
-                {
-                    writer(cos, value);
-                    cos.Flush();
-                    mm.Position = 0;
-                    return mm.ToArray();
-                }
+                { typeof(bool), (stream, value) => stream.WriteBool((bool)value) },
+                { typeof(int), (stream, value) => stream.WriteSInt32((int)value) },
+                { typeof(uint), (stream, value) => stream.WriteUInt32((uint)value) },
+                { typeof(long), (stream, value) => stream.WriteSInt64((long)value) },
+                { typeof(ulong), (stream, value) => stream.WriteUInt64((ulong)value) },
+                { typeof(byte[]), (stream, value) => stream.WriteBytes(ByteString.CopyFrom((byte[])value)) }
             };
 
-        return null;
-    }
-
-    private static Func<byte[], object> GetPrimitiveDeserializer(Type type)
-    {
-        if (_primitiveReaders.TryGetValue(type, out var reader))
-            return bytes =>
+        private static readonly Dictionary<Type, Func<CodedInputStream, object>> _primitiveReaders =
+            new Dictionary<Type, Func<CodedInputStream, object>>()
             {
-                using (var cis = new CodedInputStream(bytes))
-                {
-                    return reader(cis);
-                }
+                { typeof(bool), stream => stream.ReadBool() },
+                { typeof(int), stream => stream.ReadSInt32() },
+                { typeof(uint), stream => stream.ReadUInt32() },
+                { typeof(long), stream => stream.ReadSInt64() },
+                { typeof(ulong), stream => stream.ReadUInt64() },
+                { typeof(byte[]), stream => stream.ReadBytes().ToByteArray() }
             };
 
-        return null;
-    }
-
-    //Done: make a unit test to test Serialize / Deserialize different types such as int,string,long,Block,Hash....
-    public static byte[] Serialize(object value)
-    {
-        if (value == null) return null;
-
-        var type = value.GetType();
-        var primitiveSerializer = GetPrimitiveSerializer(type);
-        if (primitiveSerializer != null) return primitiveSerializer(value);
-
-        if (type == typeof(string)) return Encoding.UTF8.GetBytes((string)value);
-
-        if (type.IsEnum) return Serialize((int)value);
-
-        if (typeof(IMessage).IsAssignableFrom(type))
+        private static Func<object, byte[]> GetPrimitiveSerializer(Type type)
         {
-            var v = (IMessage)value;
-            return v.ToByteArray();
+            if (_primitiveWriters.TryGetValue(type, out var writer))
+                return value =>
+                {
+                    using (var mm = new MemoryStream())
+                    using (var cos = new CodedOutputStream(mm))
+                    {
+                        writer(cos, value);
+                        cos.Flush();
+                        mm.Position = 0;
+                        return mm.ToArray();
+                    }
+                };
+
+            return null;
         }
 
-        throw new InvalidOperationException($"Invalid type {type}.");
-    }
-
-    public static T Deserialize<T>(byte[] bytes)
-    {
-        if (bytes == null)
-            return default;
-
-        var type = typeof(T);
-        var primitiveDeserializer = GetPrimitiveDeserializer(type);
-        if (primitiveDeserializer != null)
+        private static Func<byte[], object> GetPrimitiveDeserializer(Type type)
         {
-            if (bytes.Length > 0) return (T)primitiveDeserializer(bytes);
+            if (_primitiveReaders.TryGetValue(type, out var reader))
+                return bytes =>
+                {
+                    using (var cis = new CodedInputStream(bytes))
+                    {
+                        return reader(cis);
+                    }
+                };
 
-            return default;
+            return null;
         }
 
-        if (type == typeof(string)) return (T)(object)Encoding.UTF8.GetString(bytes);
-
-        if (type.IsEnum) return (T)(object)Deserialize<int>(bytes);
-
-        if (typeof(IMessage).IsAssignableFrom(type))
+        //Done: make a unit test to test Serialize / Deserialize different types such as int,string,long,Block,Hash....
+        public static byte[] Serialize(object value)
         {
-            var instance = (IMessage)Activator.CreateInstance(type);
-            instance.MergeFrom(bytes);
-            return (T)instance;
+            if (value == null) return null;
+
+            var type = value.GetType();
+            var primitiveSerializer = GetPrimitiveSerializer(type);
+            if (primitiveSerializer != null) return primitiveSerializer(value);
+
+            if (type == typeof(string)) return Encoding.UTF8.GetBytes((string)value);
+
+            if (type.IsEnum) return Serialize((int)value);
+
+            if (typeof(IMessage).IsAssignableFrom(type))
+            {
+                var v = (IMessage)value;
+                return v.ToByteArray();
+            }
+
+            throw new InvalidOperationException($"Invalid type {type}.");
         }
 
-        throw new InvalidOperationException($"Invalid type {type}.");
+        public static T Deserialize<T>(byte[] bytes)
+        {
+            if (bytes == null)
+                return default;
+
+            var type = typeof(T);
+            var primitiveDeserializer = GetPrimitiveDeserializer(type);
+            if (primitiveDeserializer != null)
+            {
+                if (bytes.Length > 0) return (T)primitiveDeserializer(bytes);
+
+                return default;
+            }
+
+            if (type == typeof(string)) return (T)(object)Encoding.UTF8.GetString(bytes);
+
+            if (type.IsEnum) return (T)(object)Deserialize<int>(bytes);
+
+            if (typeof(IMessage).IsAssignableFrom(type))
+            {
+                var instance = (IMessage)Activator.CreateInstance(type);
+                instance.MergeFrom(bytes);
+                return (T)instance;
+            }
+
+            throw new InvalidOperationException($"Invalid type {type}.");
+        }
     }
 }

--- a/src/AElf.Types/IBlockBase.cs
+++ b/src/AElf.Types/IBlockBase.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
 using AElf.Types;
 
-namespace AElf;
-
-public interface IBlockBase : IHashProvider
+namespace AElf
 {
-    IEnumerable<Hash> TransactionIds { get; }
+
+    public interface IBlockBase : IHashProvider
+    {
+        IEnumerable<Hash> TransactionIds { get; }
+    }
 }

--- a/src/AElf.Types/IHashProvider.cs
+++ b/src/AElf.Types/IHashProvider.cs
@@ -1,8 +1,10 @@
 using AElf.Types;
 
-namespace AElf;
-
-public interface IHashProvider
+namespace AElf
 {
-    Hash GetHash();
+
+    public interface IHashProvider
+    {
+        Hash GetHash();
+    }
 }

--- a/src/AElf.Types/ISmartContract.cs
+++ b/src/AElf.Types/ISmartContract.cs
@@ -1,5 +1,7 @@
-﻿namespace AElf;
-
-public interface ISmartContract
+﻿namespace AElf
 {
+
+    public interface ISmartContract
+    {
+    }
 }

--- a/src/AElf.Types/Protobuf/FileDescriptorExtensions.cs
+++ b/src/AElf.Types/Protobuf/FileDescriptorExtensions.cs
@@ -1,13 +1,15 @@
 using Google.Protobuf.Reflection;
 
-namespace AElf;
-
-public static class FileDescriptorExtensions
+namespace AElf
 {
-    public static string GetIdentity(this FileDescriptor descriptor)
-    {
-        if (descriptor.CustomOptions.TryGetString(500001, out var id)) return id;
 
-        return "";
+    public static class FileDescriptorExtensions
+    {
+        public static string GetIdentity(this FileDescriptor descriptor)
+        {
+            if (descriptor.CustomOptions.TryGetString(500001, out var id)) return id;
+
+            return "";
+        }
     }
 }

--- a/src/AElf.Types/Types/Address.cs
+++ b/src/AElf.Types/Types/Address.cs
@@ -1,156 +1,159 @@
 ﻿using System;
 using Google.Protobuf;
 
-namespace AElf.Types;
-
-public partial class Address : ICustomDiagnosticMessage, IComparable<Address>
+namespace AElf.Types
 {
-    private string _formattedAddress;
 
-    // Make private to avoid confusion
-    private Address(byte[] bytes)
+    public partial class Address : ICustomDiagnosticMessage, IComparable<Address>
     {
-        if (bytes.Length != AElfConstants.AddressHashLength)
-            throw new ArgumentException("Invalid bytes.", nameof(bytes));
+        private string _formattedAddress;
 
-        Value = ByteString.CopyFrom(bytes);
-    }
-
-    public int CompareTo(Address that)
-    {
-        if (that == null) throw new InvalidOperationException("Cannot compare address when address is null.");
-
-        return CompareAddress(this, that);
-    }
-
-    /// <summary>
-    ///     Used to override IMessage's default string representation.
-    /// </summary>
-    /// <returns></returns>
-    public string ToDiagnosticString()
-    {
-        return $@"""{ToBase58()}""";
-    }
-
-    // TODO: It should be an address generation method of KeyPair, instead of Address.FromPublicKey
-    public static Address FromPublicKey(byte[] bytes)
-    {
-        var hash = bytes.ComputeHash().ComputeHash();
-        return new Address(hash);
-    }
-
-    /// <summary>
-    ///     Loads the content value from 32-byte long byte array.
-    /// </summary>
-    /// <param name="bytes"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
-    public static Address FromBytes(byte[] bytes)
-    {
-        if (bytes.Length != AElfConstants.AddressHashLength)
-            throw new ArgumentException("Invalid bytes.", nameof(bytes));
-
-        return new Address
+        // Make private to avoid confusion
+        private Address(byte[] bytes)
         {
-            Value = ByteString.CopyFrom(bytes)
-        };
+            if (bytes.Length != AElfConstants.AddressHashLength)
+                throw new ArgumentException("Invalid bytes.", nameof(bytes));
+
+            Value = ByteString.CopyFrom(bytes);
+        }
+
+        public int CompareTo(Address that)
+        {
+            if (that == null) throw new InvalidOperationException("Cannot compare address when address is null.");
+
+            return CompareAddress(this, that);
+        }
+
+        /// <summary>
+        ///     Used to override IMessage's default string representation.
+        /// </summary>
+        /// <returns></returns>
+        public string ToDiagnosticString()
+        {
+            return $@"""{ToBase58()}""";
+        }
+
+        // TODO: It should be an address generation method of KeyPair, instead of Address.FromPublicKey
+        public static Address FromPublicKey(byte[] bytes)
+        {
+            var hash = bytes.ComputeHash().ComputeHash();
+            return new Address(hash);
+        }
+
+        /// <summary>
+        ///     Loads the content value from 32-byte long byte array.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static Address FromBytes(byte[] bytes)
+        {
+            if (bytes.Length != AElfConstants.AddressHashLength)
+                throw new ArgumentException("Invalid bytes.", nameof(bytes));
+
+            return new Address
+            {
+                Value = ByteString.CopyFrom(bytes)
+            };
+        }
+
+        /// <summary>
+        ///     Dumps the content value to byte array.
+        /// </summary>
+        /// <returns></returns>
+        public byte[] ToByteArray()
+        {
+            return Value.ToByteArray();
+        }
+
+        /// <summary>
+        ///     Construct address from base58 encoded string.
+        /// </summary>
+        /// <param name="inputStr"></param>
+        /// <returns></returns>
+        public static Address FromBase58(string inputStr)
+        {
+            return FromBytes(Base58CheckEncoding.Decode(inputStr));
+        }
+
+        /// <summary>
+        ///     Converts address into base58 representation.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public string ToBase58()
+        {
+            if (_formattedAddress != null)
+                return _formattedAddress;
+
+            if (Value.Length != AElfConstants.AddressHashLength)
+                throw new ArgumentException("Invalid address", nameof(Value));
+
+            var pubKeyHash = Base58CheckEncoding.Encode(Value.ToByteArray());
+            return _formattedAddress = pubKeyHash;
+        }
+
+        public static bool operator ==(Address address1, Address address2)
+        {
+            return address1?.Equals(address2) ?? ReferenceEquals(address2, null);
+        }
+
+        public static bool operator !=(Address address1, Address address2)
+        {
+            return !(address1 == address2);
+        }
+
+        public static bool operator <(Address address1, Address address2)
+        {
+            return CompareAddress(address1, address2) < 0;
+        }
+
+        public static bool operator >(Address address1, Address address2)
+        {
+            return CompareAddress(address1, address2) > 0;
+        }
+
+        private static int CompareAddress(Address address1, Address address2)
+        {
+            if (address1 != null)
+                return address2 == null ? 1 : ByteStringHelper.Compare(address1.Value, address2.Value);
+
+            if (address2 == null) return 0;
+
+            return -1;
+        }
     }
 
-    /// <summary>
-    ///     Dumps the content value to byte array.
-    /// </summary>
-    /// <returns></returns>
-    public byte[] ToByteArray()
+    public class ChainAddress
     {
-        return Value.ToByteArray();
-    }
+        private string _formatted;
 
-    /// <summary>
-    ///     Construct address from base58 encoded string.
-    /// </summary>
-    /// <param name="inputStr"></param>
-    /// <returns></returns>
-    public static Address FromBase58(string inputStr)
-    {
-        return FromBytes(Base58CheckEncoding.Decode(inputStr));
-    }
+        public ChainAddress(Address address, int chainId)
+        {
+            Address = address;
+            ChainId = chainId;
+        }
 
-    /// <summary>
-    ///     Converts address into base58 representation.
-    /// </summary>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
-    public string ToBase58()
-    {
-        if (_formattedAddress != null)
-            return _formattedAddress;
+        public Address Address { get; }
+        public int ChainId { get; }
 
-        if (Value.Length != AElfConstants.AddressHashLength)
-            throw new ArgumentException("Invalid address", nameof(Value));
+        public static ChainAddress Parse(string chainAddressString, string symbol)
+        {
+            var arr = chainAddressString.Split('_');
+            if (arr[0] != symbol) throw new ArgumentException("invalid chain address", nameof(chainAddressString));
 
-        var pubKeyHash = Base58CheckEncoding.Encode(Value.ToByteArray());
-        return _formattedAddress = pubKeyHash;
-    }
+            var address = Address.FromBase58(arr[1]);
+            var chainId = Base58CheckEncoding.Decode(arr[2]).ToInt32(false);
 
-    public static bool operator ==(Address address1, Address address2)
-    {
-        return address1?.Equals(address2) ?? ReferenceEquals(address2, null);
-    }
+            return new ChainAddress(address, chainId);
+        }
 
-    public static bool operator !=(Address address1, Address address2)
-    {
-        return !(address1 == address2);
-    }
-
-    public static bool operator <(Address address1, Address address2)
-    {
-        return CompareAddress(address1, address2) < 0;
-    }
-
-    public static bool operator >(Address address1, Address address2)
-    {
-        return CompareAddress(address1, address2) > 0;
-    }
-
-    private static int CompareAddress(Address address1, Address address2)
-    {
-        if (address1 != null) return address2 == null ? 1 : ByteStringHelper.Compare(address1.Value, address2.Value);
-
-        if (address2 == null) return 0;
-
-        return -1;
-    }
-}
-
-public class ChainAddress
-{
-    private string _formatted;
-
-    public ChainAddress(Address address, int chainId)
-    {
-        Address = address;
-        ChainId = chainId;
-    }
-
-    public Address Address { get; }
-    public int ChainId { get; }
-
-    public static ChainAddress Parse(string chainAddressString, string symbol)
-    {
-        var arr = chainAddressString.Split('_');
-        if (arr[0] != symbol) throw new ArgumentException("invalid chain address", nameof(chainAddressString));
-
-        var address = Address.FromBase58(arr[1]);
-        var chainId = Base58CheckEncoding.Decode(arr[2]).ToInt32(false);
-
-        return new ChainAddress(address, chainId);
-    }
-
-    public string GetFormatted(string addressPrefix, int chainId)
-    {
-        if (_formatted != null) return _formatted;
-        var addressSuffix = Base58CheckEncoding.Encode(chainId.ToBytes(false));
-        _formatted = $"{addressPrefix}_{Address.ToBase58()}_{addressSuffix}";
-        return _formatted;
+        public string GetFormatted(string addressPrefix, int chainId)
+        {
+            if (_formatted != null) return _formatted;
+            var addressSuffix = Base58CheckEncoding.Encode(chainId.ToBytes(false));
+            _formatted = $"{addressPrefix}_{Address.ToBase58()}_{addressSuffix}";
+            return _formatted;
+        }
     }
 }

--- a/src/AElf.Types/Types/BigIntValue.cs
+++ b/src/AElf.Types/Types/BigIntValue.cs
@@ -3,149 +3,151 @@ using System.Linq;
 using System.Numerics;
 using Google.Protobuf.WellKnownTypes;
 
-namespace AElf.Types;
-
-public partial class BigIntValue : IComparable, IComparable<BigIntValue>
+namespace AElf.Types
 {
-    public int CompareTo(object obj)
+
+    public partial class BigIntValue : IComparable, IComparable<BigIntValue>
     {
-        if (!(obj is BigIntValue bigInt)) throw new InvalidOperationException();
-
-        return CompareTo(bigInt);
-    }
-
-    public int CompareTo(BigIntValue other)
-    {
-        if (LessThan(this, other)) return -1;
-
-        if (Value == other.Value) return 0;
-
-        return 1;
-    }
-
-    public static implicit operator BigIntValue(string str)
-    {
-        if (str.All(c => '0' <= c || c <= '9' || c == '_' || c == '-'))
+        public int CompareTo(object obj)
         {
-            if (str.Contains('-'))
-                if (!str.StartsWith("-") || str.Count(c => c == '-') > 1)
-                    throw new ArgumentException("Invalid big integer string.");
+            if (!(obj is BigIntValue bigInt)) throw new InvalidOperationException();
 
-            str = str.Replace("_", string.Empty);
+            return CompareTo(bigInt);
+        }
+
+        public int CompareTo(BigIntValue other)
+        {
+            if (LessThan(this, other)) return -1;
+
+            if (Value == other.Value) return 0;
+
+            return 1;
+        }
+
+        public static implicit operator BigIntValue(string str)
+        {
+            if (str.All(c => '0' <= c || c <= '9' || c == '_' || c == '-'))
+            {
+                if (str.Contains('-'))
+                    if (!str.StartsWith("-") || str.Count(c => c == '-') > 1)
+                        throw new ArgumentException("Invalid big integer string.");
+
+                str = str.Replace("_", string.Empty);
+                return new BigIntValue
+                {
+                    Value = str
+                };
+            }
+
+            throw new ArgumentException("Invalid big integer string.");
+        }
+
+        public static implicit operator BigIntValue(ushort value)
+        {
             return new BigIntValue
             {
-                Value = str
+                Value = value.ToString()
             };
         }
 
-        throw new ArgumentException("Invalid big integer string.");
-    }
-
-    public static implicit operator BigIntValue(ushort value)
-    {
-        return new BigIntValue
+        public static implicit operator BigIntValue(short value)
         {
-            Value = value.ToString()
-        };
-    }
+            return new BigIntValue
+            {
+                Value = value.ToString()
+            };
+        }
 
-    public static implicit operator BigIntValue(short value)
-    {
-        return new BigIntValue
+        public static implicit operator BigIntValue(uint value)
         {
-            Value = value.ToString()
-        };
-    }
+            return new BigIntValue
+            {
+                Value = value.ToString()
+            };
+        }
 
-    public static implicit operator BigIntValue(uint value)
-    {
-        return new BigIntValue
+        public static implicit operator BigIntValue(int value)
         {
-            Value = value.ToString()
-        };
-    }
+            return new BigIntValue
+            {
+                Value = value.ToString()
+            };
+        }
 
-    public static implicit operator BigIntValue(int value)
-    {
-        return new BigIntValue
+        public static implicit operator BigIntValue(ulong value)
         {
-            Value = value.ToString()
-        };
-    }
+            return new BigIntValue
+            {
+                Value = value.ToString()
+            };
+        }
 
-    public static implicit operator BigIntValue(ulong value)
-    {
-        return new BigIntValue
+        public static implicit operator BigIntValue(long value)
         {
-            Value = value.ToString()
-        };
-    }
+            return new BigIntValue
+            {
+                Value = value.ToString()
+            };
+        }
 
-    public static implicit operator BigIntValue(long value)
-    {
-        return new BigIntValue
+        public static implicit operator BigIntValue(Int32Value value)
         {
-            Value = value.ToString()
-        };
-    }
+            return new BigIntValue
+            {
+                Value = value.Value.ToString()
+            };
+        }
 
-    public static implicit operator BigIntValue(Int32Value value)
-    {
-        return new BigIntValue
+        public static implicit operator BigIntValue(Int64Value value)
         {
-            Value = value.Value.ToString()
-        };
-    }
+            return new BigIntValue
+            {
+                Value = value.Value.ToString()
+            };
+        }
 
-    public static implicit operator BigIntValue(Int64Value value)
-    {
-        return new BigIntValue
+        public static implicit operator BigInteger(BigIntValue value)
         {
-            Value = value.Value.ToString()
-        };
+            return ConvertStringToBigInteger(value.Value);
+        }
+
+        private static BigInteger ConvertStringToBigInteger(string str)
+        {
+            str = str.Replace("_", string.Empty);
+            if (BigInteger.TryParse(str, out var bigInteger)) return bigInteger;
+
+            throw new ArgumentException("Incorrect arguments.");
+        }
+
+        private static bool LessThan(in BigIntValue a, in BigIntValue b)
+        {
+            var aBigInt = ConvertStringToBigInteger(a.Value);
+            var bBigInt = ConvertStringToBigInteger(b.Value);
+            return aBigInt < bBigInt;
+        }
+
+        #region < <= > >=
+
+        public static bool operator <(in BigIntValue a, in BigIntValue b)
+        {
+            return LessThan(in a, in b);
+        }
+
+        public static bool operator >(in BigIntValue a, in BigIntValue b)
+        {
+            return LessThan(in b, in a);
+        }
+
+        public static bool operator >=(in BigIntValue a, in BigIntValue b)
+        {
+            return !LessThan(in a, in b);
+        }
+
+        public static bool operator <=(in BigIntValue a, in BigIntValue b)
+        {
+            return !LessThan(in b, in a);
+        }
+
+        #endregion
     }
-
-    public static implicit operator BigInteger(BigIntValue value)
-    {
-        return ConvertStringToBigInteger(value.Value);
-    }
-
-    private static BigInteger ConvertStringToBigInteger(string str)
-    {
-        str = str.Replace("_", string.Empty);
-        if (BigInteger.TryParse(str, out var bigInteger)) return bigInteger;
-
-        throw new ArgumentException("Incorrect arguments.");
-    }
-
-    private static bool LessThan(in BigIntValue a, in BigIntValue b)
-    {
-        var aBigInt = ConvertStringToBigInteger(a.Value);
-        var bBigInt = ConvertStringToBigInteger(b.Value);
-        return aBigInt < bBigInt;
-    }
-
-    #region < <= > >=
-
-    public static bool operator <(in BigIntValue a, in BigIntValue b)
-    {
-        return LessThan(in a, in b);
-    }
-
-    public static bool operator >(in BigIntValue a, in BigIntValue b)
-    {
-        return LessThan(in b, in a);
-    }
-
-    public static bool operator >=(in BigIntValue a, in BigIntValue b)
-    {
-        return !LessThan(in a, in b);
-    }
-
-    public static bool operator <=(in BigIntValue a, in BigIntValue b)
-    {
-        return !LessThan(in b, in a);
-    }
-
-    #endregion
 }

--- a/src/AElf.Types/Types/Hash.cs
+++ b/src/AElf.Types/Types/Hash.cs
@@ -5,133 +5,135 @@ using System.Linq;
 using Google.Protobuf;
 
 // ReSharper disable once CheckNamespace
-namespace AElf.Types;
-
-public partial class Hash : ICustomDiagnosticMessage, IComparable<Hash>, IEnumerable<byte>
+namespace AElf.Types
 {
-    public static readonly Hash Empty = LoadFromByteArray(Enumerable.Range(0, AElfConstants.HashByteArrayLength)
-        .Select(x => byte.MinValue).ToArray());
 
-    public int CompareTo(Hash that)
+    public partial class Hash : ICustomDiagnosticMessage, IComparable<Hash>, IEnumerable<byte>
     {
-        if (that == null)
-            throw new InvalidOperationException("Cannot compare hash when hash is null");
+        public static readonly Hash Empty = LoadFromByteArray(Enumerable.Range(0, AElfConstants.HashByteArrayLength)
+            .Select(x => byte.MinValue).ToArray());
 
-        return CompareHash(this, that);
-    }
-
-    /// <summary>
-    ///     Used to override IMessage's default string representation.
-    /// </summary>
-    /// <returns></returns>
-    public string ToDiagnosticString()
-    {
-        return $@"""{ToHex()}""";
-    }
-
-    public IEnumerator<byte> GetEnumerator()
-    {
-        return Value.GetEnumerator();
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    /// <summary>
-    ///     Loads the content value from 32-byte long byte array.
-    /// </summary>
-    /// <param name="bytes"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
-    public static Hash LoadFromByteArray(byte[] bytes)
-    {
-        if (bytes.Length != AElfConstants.HashByteArrayLength)
-            throw new ArgumentException("Invalid bytes.", nameof(bytes));
-
-        return new Hash
+        public int CompareTo(Hash that)
         {
-            Value = ByteString.CopyFrom(bytes)
-        };
-    }
+            if (that == null)
+                throw new InvalidOperationException("Cannot compare hash when hash is null");
 
-    /// <summary>
-    ///     Loads the content value represented in base64.
-    /// </summary>
-    /// <param name="base64"></param>
-    /// <returns></returns>
-    public static Hash LoadFromBase64(string base64)
-    {
-        var bytes = Convert.FromBase64String(base64);
-        return LoadFromByteArray(bytes);
-    }
+            return CompareHash(this, that);
+        }
 
-    /// <summary>
-    ///     Loads the content value represented in hex string.
-    /// </summary>
-    /// <param name="hex"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    public static Hash LoadFromHex(string hex)
-    {
-        var bytes = ByteArrayHelper.HexStringToByteArray(hex);
-        return LoadFromByteArray(bytes);
-    }
+        /// <summary>
+        ///     Used to override IMessage's default string representation.
+        /// </summary>
+        /// <returns></returns>
+        public string ToDiagnosticString()
+        {
+            return $@"""{ToHex()}""";
+        }
 
-    /// <summary>
-    ///     Dumps the content value to byte array.
-    /// </summary>
-    /// <returns></returns>
-    public byte[] ToByteArray()
-    {
-        return Value.ToByteArray();
-    }
+        public IEnumerator<byte> GetEnumerator()
+        {
+            return Value.GetEnumerator();
+        }
 
-    /// <summary>
-    ///     Converts hash into hexadecimal representation.
-    /// </summary>
-    /// <returns></returns>
-    public string ToHex()
-    {
-        return Value.ToHex();
-    }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
 
-    /// <summary>
-    ///     Converts hash into int64 value.
-    /// </summary>
-    /// <returns></returns>
-    public long ToInt64()
-    {
-        return ToByteArray().ToInt64(true);
-    }
+        /// <summary>
+        ///     Loads the content value from 32-byte long byte array.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static Hash LoadFromByteArray(byte[] bytes)
+        {
+            if (bytes.Length != AElfConstants.HashByteArrayLength)
+                throw new ArgumentException("Invalid bytes.", nameof(bytes));
 
-    public static bool operator ==(Hash h1, Hash h2)
-    {
-        return h1?.Equals(h2) ?? ReferenceEquals(h2, null);
-    }
+            return new Hash
+            {
+                Value = ByteString.CopyFrom(bytes)
+            };
+        }
 
-    public static bool operator !=(Hash h1, Hash h2)
-    {
-        return !(h1 == h2);
-    }
+        /// <summary>
+        ///     Loads the content value represented in base64.
+        /// </summary>
+        /// <param name="base64"></param>
+        /// <returns></returns>
+        public static Hash LoadFromBase64(string base64)
+        {
+            var bytes = Convert.FromBase64String(base64);
+            return LoadFromByteArray(bytes);
+        }
 
-    public static bool operator <(Hash h1, Hash h2)
-    {
-        return CompareHash(h1, h2) < 0;
-    }
+        /// <summary>
+        ///     Loads the content value represented in hex string.
+        /// </summary>
+        /// <param name="hex"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public static Hash LoadFromHex(string hex)
+        {
+            var bytes = ByteArrayHelper.HexStringToByteArray(hex);
+            return LoadFromByteArray(bytes);
+        }
 
-    public static bool operator >(Hash h1, Hash h2)
-    {
-        return CompareHash(h1, h2) > 0;
-    }
+        /// <summary>
+        ///     Dumps the content value to byte array.
+        /// </summary>
+        /// <returns></returns>
+        public byte[] ToByteArray()
+        {
+            return Value.ToByteArray();
+        }
 
-    private static int CompareHash(Hash hash1, Hash hash2)
-    {
-        if (hash1 != null) return hash2 == null ? 1 : ByteStringHelper.Compare(hash1.Value, hash2.Value);
+        /// <summary>
+        ///     Converts hash into hexadecimal representation.
+        /// </summary>
+        /// <returns></returns>
+        public string ToHex()
+        {
+            return Value.ToHex();
+        }
 
-        if (hash2 == null) return 0;
+        /// <summary>
+        ///     Converts hash into int64 value.
+        /// </summary>
+        /// <returns></returns>
+        public long ToInt64()
+        {
+            return ToByteArray().ToInt64(true);
+        }
 
-        return -1;
+        public static bool operator ==(Hash h1, Hash h2)
+        {
+            return h1?.Equals(h2) ?? ReferenceEquals(h2, null);
+        }
+
+        public static bool operator !=(Hash h1, Hash h2)
+        {
+            return !(h1 == h2);
+        }
+
+        public static bool operator <(Hash h1, Hash h2)
+        {
+            return CompareHash(h1, h2) < 0;
+        }
+
+        public static bool operator >(Hash h1, Hash h2)
+        {
+            return CompareHash(h1, h2) > 0;
+        }
+
+        private static int CompareHash(Hash hash1, Hash hash2)
+        {
+            if (hash1 != null) return hash2 == null ? 1 : ByteStringHelper.Compare(hash1.Value, hash2.Value);
+
+            if (hash2 == null) return 0;
+
+            return -1;
+        }
     }
 }

--- a/src/AElf.Types/Types/Transaction.cs
+++ b/src/AElf.Types/Types/Transaction.cs
@@ -1,44 +1,46 @@
 using System;
 using Google.Protobuf;
 
-namespace AElf.Types;
-
-public partial class Transaction
+namespace AElf.Types
 {
-    private Hash _transactionId;
 
-    public Hash GetHash()
+    public partial class Transaction
     {
-        if (_transactionId == null)
-            _transactionId = HashHelper.ComputeFrom(GetSignatureData());
+        private Hash _transactionId;
 
-        return _transactionId;
-    }
+        public Hash GetHash()
+        {
+            if (_transactionId == null)
+                _transactionId = HashHelper.ComputeFrom(GetSignatureData());
 
-    public bool VerifyFields()
-    {
-        if (To == null || From == null)
-            return false;
+            return _transactionId;
+        }
 
-        if (RefBlockNumber < 0)
-            return false;
+        public bool VerifyFields()
+        {
+            if (To == null || From == null)
+                return false;
 
-        if (string.IsNullOrEmpty(MethodName))
-            return false;
+            if (RefBlockNumber < 0)
+                return false;
 
-        return true;
-    }
+            if (string.IsNullOrEmpty(MethodName))
+                return false;
 
-    private byte[] GetSignatureData()
-    {
-        if (!VerifyFields())
-            throw new InvalidOperationException($"Invalid transaction: {this}");
+            return true;
+        }
 
-        if (Signature.IsEmpty)
-            return this.ToByteArray();
+        private byte[] GetSignatureData()
+        {
+            if (!VerifyFields())
+                throw new InvalidOperationException($"Invalid transaction: {this}");
 
-        var transaction = Clone();
-        transaction.Signature = ByteString.Empty;
-        return transaction.ToByteArray();
+            if (Signature.IsEmpty)
+                return this.ToByteArray();
+
+            var transaction = Clone();
+            transaction.Signature = ByteString.Empty;
+            return transaction.ToByteArray();
+        }
     }
 }


### PR DESCRIPTION
Changed syntax to C#8.0 for AElf.Cryptography & AElf.Types.

No logic was changed. Syntax changes:
1) Changed namespace XX; to namespace XX {}
2) Changed Foo foo = new(); to Foo foo = new Foo();