### PR TITLE
Add methods to set/get CodeCheckProposalExpirationTimePeriod

### DIFF
--- a/contract/AElf.Contracts.Genesis/BasicContractZero.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZero.cs
@@ -84,6 +84,12 @@ public partial class BasicContractZero : BasicContractZeroImplContainer.BasicCon
         return new Int32Value { Value = expirationTimePeriod };
     }
 
+    public override Int32Value GetCodeCheckProposalExpirationTimePeriod(Empty input)
+    {
+        var expirationTimePeriod = GetCodeCheckProposalExpirationTimePeriod();
+        return new Int32Value { Value = expirationTimePeriod };
+    }
+
     public override Address GetSigner(Address input)
     {
         return State.SignerMap[input];
@@ -245,7 +251,7 @@ public partial class BasicContractZero : BasicContractZeroImplContainer.BasicCon
                 ContractMethodName = input.CodeCheckReleaseMethod,
                 Params = input.ContractInput,
                 OrganizationAddress = codeCheckController.OwnerAddress,
-                ExpiredTime = Context.CurrentBlockTime.AddSeconds(CodeCheckProposalExpirationTimePeriod)
+                ExpiredTime = Context.CurrentBlockTime.AddSeconds(GetCodeCheckProposalExpirationTimePeriod())
             },
             OriginProposer = proposedInfo.Proposer
         };
@@ -389,6 +395,13 @@ public partial class BasicContractZero : BasicContractZeroImplContainer.BasicCon
     {
         AssertSenderAddressWith(State.ContractDeploymentController.Value.OwnerAddress);
         State.ContractProposalExpirationTimePeriod.Value = input.ExpirationTimePeriod;
+        return new Empty();
+    }
+
+    public override Empty SetCodeCheckProposalExpirationTimePeriod(Int32Value input)
+    {
+        AssertSenderAddressWith(State.ContractDeploymentController.Value.OwnerAddress);
+        State.CodeCheckProposalExpirationTimePeriod.Value = input.Value;
         return new Empty();
     }
 

--- a/contract/AElf.Contracts.Genesis/BasicContractZero.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZero.cs
@@ -401,6 +401,7 @@ public partial class BasicContractZero : BasicContractZeroImplContainer.BasicCon
     public override Empty SetCodeCheckProposalExpirationTimePeriod(Int32Value input)
     {
         AssertSenderAddressWith(State.ContractDeploymentController.Value.OwnerAddress);
+        Assert(input.Value > 0, "Invalid expiration time period.");
         State.CodeCheckProposalExpirationTimePeriod.Value = input.Value;
         return new Empty();
     }

--- a/contract/AElf.Contracts.Genesis/BasicContractZeroState.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZeroState.cs
@@ -36,4 +36,7 @@ public partial class BasicContractZeroState : ContractState
     public SingletonState<int> ContractProposalExpirationTimePeriod { get; set; }
     
     public MappedState<Address, Address> SignerMap { get; set; }
+
+    public SingletonState<int> CodeCheckProposalExpirationTimePeriod { get; set; }
+
 }

--- a/contract/AElf.Contracts.Genesis/BasicContractZero_Constants.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZero_Constants.cs
@@ -3,7 +3,7 @@ namespace AElf.Contracts.Genesis;
 public partial class BasicContractZero
 {
     public const int ContractProposalExpirationTimePeriod = 259200; // 60 * 60 * 72
-    public const int CodeCheckProposalExpirationTimePeriod = 600; // 60 * 10
+    public const int DefaultCodeCheckProposalExpirationTimePeriod = 600; // 60 * 10
     private const int MinimalApprovalThreshold = 6667;
     private const int MaximalAbstentionThreshold = 1000;
     private const int MaximalRejectionThreshold = 1000;

--- a/contract/AElf.Contracts.Genesis/BasicContractZero_Constants.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZero_Constants.cs
@@ -3,7 +3,7 @@ namespace AElf.Contracts.Genesis;
 public partial class BasicContractZero
 {
     public const int ContractProposalExpirationTimePeriod = 259200; // 60 * 60 * 72
-    public const int DefaultCodeCheckProposalExpirationTimePeriod = 600; // 60 * 10
+    public const int DefaultCodeCheckProposalExpirationTimePeriod = 900; // 60 * 15
     private const int MinimalApprovalThreshold = 6667;
     private const int MaximalAbstentionThreshold = 1000;
     private const int MaximalRejectionThreshold = 1000;

--- a/contract/AElf.Contracts.Genesis/BasicContractZero_Helper.cs
+++ b/contract/AElf.Contracts.Genesis/BasicContractZero_Helper.cs
@@ -286,6 +286,13 @@ public partial class BasicContractZero
             : State.ContractProposalExpirationTimePeriod.Value;
     }
 
+    private int GetCodeCheckProposalExpirationTimePeriod()
+    {
+        return State.CodeCheckProposalExpirationTimePeriod.Value == 0
+            ? DefaultCodeCheckProposalExpirationTimePeriod
+            : State.CodeCheckProposalExpirationTimePeriod.Value;
+    }
+
     private void AssertCurrentMiner()
     {
         RequireConsensusContractStateSet();
@@ -310,7 +317,7 @@ public partial class BasicContractZero
         {
             Proposer = Context.Self,
             Status = ContractProposingInputStatus.CodeCheckProposed,
-            ExpiredTime = Context.CurrentBlockTime.AddSeconds(CodeCheckProposalExpirationTimePeriod),
+            ExpiredTime = Context.CurrentBlockTime.AddSeconds(GetCodeCheckProposalExpirationTimePeriod()),
             Author = Context.Sender
         };
         State.ContractProposingInputMap[proposingInputHash] = proposedInfo;

--- a/contract/AElf.Contracts.MultiToken/TokenContract_Fees.cs
+++ b/contract/AElf.Contracts.MultiToken/TokenContract_Fees.cs
@@ -140,7 +140,7 @@ public partial class TokenContract
         //configuration_key:UserContractMethod_contractAddress_methodName
         var spec = State.ConfigurationContract.GetConfiguration.Call(new StringValue
         {
-            Value = $"{TokenContractConstants.UserContractMethodFeeKey}_{contractAddress}_{methodName}"
+            Value = $"{TokenContractConstants.UserContractMethodFeeKey}_{contractAddress.ToBase58()}_{methodName}"
         });
         var fee = new UserContractMethodFees();
         if (!spec.Value.IsNullOrEmpty())

--- a/contract/AElf.Contracts.MultiToken/TokenContract_Fees.cs
+++ b/contract/AElf.Contracts.MultiToken/TokenContract_Fees.cs
@@ -320,14 +320,14 @@ public partial class TokenContract
 
     private Dictionary<string, long> GetBaseFeeDictionary(MethodFees methodFees)
     {
-        return methodFees.Fees
+        return methodFees.Fees.Where(f => !string.IsNullOrEmpty(f.Symbol))
             .GroupBy(f => f.Symbol, f => f.BasicFee)
             .ToDictionary(g => g.Key, g => g.Sum());
     }
 
     private Dictionary<string, long> GetUserContractFeeDictionary(UserContractMethodFees fees)
     {
-        return fees.Fees
+        return fees.Fees.Where(f => !string.IsNullOrEmpty(f.Symbol)) 
             .GroupBy(f => f.Symbol, f => f.BasicFee)
             .ToDictionary(g => g.Key, g => g.Sum());
     }

--- a/protobuf/basic_contract_zero.proto
+++ b/protobuf/basic_contract_zero.proto
@@ -37,6 +37,9 @@ service BasicContractZero {
     
     rpc SetContractProposalExpirationTimePeriod(SetContractProposalExpirationTimePeriodInput) returns(google.protobuf.Empty){
     }
+
+    rpc SetCodeCheckProposalExpirationTimePeriod(google.protobuf.Int32Value) returns(google.protobuf.Empty){
+    }
     
     // Query the ContractDeploymentController authority info.
     rpc GetContractDeploymentController (google.protobuf.Empty) returns (AuthorityInfo) {
@@ -49,6 +52,10 @@ service BasicContractZero {
     }
     
     rpc GetContractProposalExpirationTimePeriod(google.protobuf.Empty) returns (google.protobuf.Int32Value){
+        option (aelf.is_view) = true;
+    }
+
+    rpc GetCodeCheckProposalExpirationTimePeriod(google.protobuf.Empty) returns (google.protobuf.Int32Value){
         option (aelf.is_view) = true;
     }
 }

--- a/test/AElf.Contracts.Genesis.Tests/GenesisContractAuthTest.cs
+++ b/test/AElf.Contracts.Genesis.Tests/GenesisContractAuthTest.cs
@@ -1391,7 +1391,7 @@ public partial class GenesisContractAuthTest : BasicContractZeroTestBase
             nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.GetCodeCheckProposalExpirationTimePeriod),
             new Empty());
         var proposalExpirationTime = Int32Value.Parser.ParseFrom(defaultTime);
-        Assert.True(proposalExpirationTime.Value == 600);
+        Assert.True(proposalExpirationTime.Value == 900);
 
         var byteResult = await Tester.CallContractMethodAsync(BasicContractZeroAddress,
             nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.GetContractDeploymentController),

--- a/test/AElf.Contracts.Genesis.Tests/GenesisContractAuthTest.cs
+++ b/test/AElf.Contracts.Genesis.Tests/GenesisContractAuthTest.cs
@@ -1373,6 +1373,67 @@ public partial class GenesisContractAuthTest : BasicContractZeroTestBase
     }
     
     [Fact]
+    public async Task SetCodeCheckProposalExpirationTime_Test()
+    {
+        var createOrganizationResult = await Tester.ExecuteContractWithMiningAsync(ParliamentAddress,
+            nameof(ParliamentContractImplContainer.ParliamentContractImplStub.CreateOrganization),
+            new CreateOrganizationInput
+            {
+                ProposalReleaseThreshold = new ProposalReleaseThreshold
+                {
+                    MinimalApprovalThreshold = 1000,
+                    MinimalVoteThreshold = 1000
+                }
+            });
+        var organizationAddress = Address.Parser.ParseFrom(createOrganizationResult.ReturnValue);
+
+        var defaultTime = await Tester.CallContractMethodAsync(BasicContractZeroAddress,
+            nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.GetCodeCheckProposalExpirationTimePeriod),
+            new Empty());
+        var proposalExpirationTime = Int32Value.Parser.ParseFrom(defaultTime);
+        Assert.True(proposalExpirationTime.Value == 600);
+
+        var byteResult = await Tester.CallContractMethodAsync(BasicContractZeroAddress,
+            nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.GetContractDeploymentController),
+            new Empty());
+        var contractDeploymentController = AuthorityInfo.Parser.ParseFrom(byteResult);
+
+        const string methodName =
+            nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.SetCodeCheckProposalExpirationTimePeriod);
+        {
+            var proposalId = await CreateProposalAsync(Tester, ParliamentAddress,
+                organizationAddress, methodName,
+                new Int32Value
+                {
+                    Value = 86400
+                }
+            );
+            await ApproveWithMinersAsync(Tester, ParliamentAddress, proposalId);
+            var txResult = await ReleaseProposalAsync(Tester, ParliamentAddress, proposalId);
+            txResult.Status.ShouldBe(TransactionResultStatus.Failed);
+            txResult.Error.ShouldContain("Unauthorized behavior.");
+        }
+        {
+            var proposalId = await CreateProposalAsync(Tester, ParliamentAddress,
+                contractDeploymentController.OwnerAddress, methodName,
+                new Int32Value
+                {
+                    Value = 86400
+                });
+            await ApproveWithMinersAsync(Tester, ParliamentAddress, proposalId);
+            var txResult2 = await ReleaseProposalAsync(Tester, ParliamentAddress, proposalId);
+            txResult2.Status.ShouldBe(TransactionResultStatus.Mined);
+
+            byteResult = await Tester.CallContractMethodAsync(BasicContractZeroAddress,
+                nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub
+                    .GetCodeCheckProposalExpirationTimePeriod),
+                new Empty());
+            var newProposalExpirationTime = Int32Value.Parser.ParseFrom(byteResult);
+            Assert.True(newProposalExpirationTime.Value == 86400);
+        }
+    }
+
+    [Fact]
     public async Task SetContractProposalExpirationTime_Test()
     {
         var createOrganizationResult = await Tester.ExecuteContractWithMiningAsync(ParliamentAddress,
@@ -1386,18 +1447,18 @@ public partial class GenesisContractAuthTest : BasicContractZeroTestBase
                 }
             });
         var organizationAddress = Address.Parser.ParseFrom(createOrganizationResult.ReturnValue);
-        
+
         var defaultTime = await Tester.CallContractMethodAsync(BasicContractZeroAddress,
             nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.GetContractProposalExpirationTimePeriod),
             new Empty());
         var contractProposalExpirationTime = Int32Value.Parser.ParseFrom(defaultTime);
         Assert.True(contractProposalExpirationTime.Value == 259200);
-        
+
         var byteResult = await Tester.CallContractMethodAsync(BasicContractZeroAddress,
             nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.GetContractDeploymentController),
             new Empty());
         var contractDeploymentController = AuthorityInfo.Parser.ParseFrom(byteResult);
-        
+
         const string methodName =
             nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.SetContractProposalExpirationTimePeriod);
         {
@@ -1422,9 +1483,10 @@ public partial class GenesisContractAuthTest : BasicContractZeroTestBase
             await ApproveWithMinersAsync(Tester, ParliamentAddress, proposalId);
             var txResult2 = await ReleaseProposalAsync(Tester, ParliamentAddress, proposalId);
             txResult2.Status.ShouldBe(TransactionResultStatus.Mined);
-            
+
             byteResult = await Tester.CallContractMethodAsync(BasicContractZeroAddress,
-                nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub.GetContractProposalExpirationTimePeriod),
+                nameof(BasicContractZeroImplContainer.BasicContractZeroImplStub
+                    .GetContractProposalExpirationTimePeriod),
                 new Empty());
             var newContractProposalExpirationTime = Int32Value.Parser.ParseFrom(byteResult);
             Assert.True(newContractProposalExpirationTime.Value == 86400);

--- a/test/AElf.Kernel.SmartContract.ExecutionPluginForMethodFee.Tests/ExecutionPluginForUserContractMethodFeeTest.cs
+++ b/test/AElf.Kernel.SmartContract.ExecutionPluginForMethodFee.Tests/ExecutionPluginForUserContractMethodFeeTest.cs
@@ -282,7 +282,8 @@ public class ExecutionPluginForUserContractContractMethodFeeTest : ExecutionPlug
         };
         var createProposalInput = new SetConfigurationInput
         {
-            Key = $"{ConfigurationKey}_{_testContractAddress}_{nameof(TestContractContainer.TestContractStub.TestMethod)}",
+            Key =
+                $"{ConfigurationKey}_{_testContractAddress.ToBase58()}_{nameof(TestContractContainer.TestContractStub.TestMethod)}",
             Value = transactionFee.ToByteString()
         };
         await ConfigurationStub.SetConfiguration.SendAsync(createProposalInput);


### PR DESCRIPTION
Now we can use SetCodeCheckProposalExpirationTimePeriod and GetCodeCheckProposalExpirationTimePeriod to manage the value of CheckProposalExpirationTimePeriod, which is responsible for setting the default expiration time for proposals.
#3538 