### PR TITLE
Throw StateKeyOverSizeException if state key is too long

### DIFF
--- a/src/AElf.Kernel.SmartContract.Shared/ISmartContractBridgeContext.cs
+++ b/src/AElf.Kernel.SmartContract.Shared/ISmartContractBridgeContext.cs
@@ -203,3 +203,23 @@ public class StateOverSizeException : SmartContractBridgeException
     {
     }
 }
+
+[Serializable]
+public class StateKeyOverSizeException : SmartContractBridgeException
+{
+    public StateKeyOverSizeException()
+    {
+    }
+
+    public StateKeyOverSizeException(string message) : base(message)
+    {
+    }
+
+    public StateKeyOverSizeException(string message, Exception inner) : base(message, inner)
+    {
+    }
+
+    protected StateKeyOverSizeException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/src/AElf.Kernel.SmartContract/HostSmartContractBridgeContext.cs
+++ b/src/AElf.Kernel.SmartContract/HostSmartContractBridgeContext.cs
@@ -111,6 +111,11 @@ public class HostSmartContractBridgeContext : IHostSmartContractBridgeContext, I
 
     public async Task<ByteString> GetStateAsync(string key)
     {
+        if (key.Length > SmartContractConstants.StateKeyMaximumLength)
+        {
+            throw new StateKeyOverSizeException(
+                $"Length of state key {key} exceeds limit of {SmartContractConstants.StateKeyMaximumLength}.");
+        }
         return await _smartContractBridgeService.GetStateAsync(
             Self, key, CurrentHeight - 1, PreviousBlockHash);
     }

--- a/src/AElf.Kernel.SmartContract/SmartContractConstants.cs
+++ b/src/AElf.Kernel.SmartContract/SmartContractConstants.cs
@@ -7,4 +7,6 @@ public class SmartContractConstants
     public const int ExecutionBranchThreshold = 15000;
 
     public const int StateSizeLimit = 128 * 1024;
+
+    public const int StateKeyMaximumLength = 255;
 }

--- a/src/AElf.Kernel.SmartContract/SmartContractConstants.cs
+++ b/src/AElf.Kernel.SmartContract/SmartContractConstants.cs
@@ -8,5 +8,6 @@ public class SmartContractConstants
 
     public const int StateSizeLimit = 128 * 1024;
 
-    public const int StateKeyMaximumLength = 255;
+    // The prefix `vs` occupies 2 lengths.
+    public const int StateKeyMaximumLength = 255 - 2;
 }

--- a/test/AElf.Contracts.TestContract.Tests/PatchedContractSecurityTests.cs
+++ b/test/AElf.Contracts.TestContract.Tests/PatchedContractSecurityTests.cs
@@ -262,7 +262,7 @@ public class PatchedContractSecurityTests : TestContractTestBase
                         StringValue = str
                     }
                 });
-            txResult.TransactionResult.Error.ShouldContain($"exceeds limit of {stateSizeLimit}");
+            txResult.TransactionResult.Error.ShouldContain($"exceeds limit");
 
             var str1 = Encoding.UTF8.GetString(new byte[10]);
             var message = new ProtobufMessage
@@ -309,7 +309,7 @@ public class PatchedContractSecurityTests : TestContractTestBase
             {
                 ProtobufValue = new ProtobufMessage()
             });
-            txResult.TransactionResult.Error.ShouldContain($"exceeds limit of {stateSizeLimit}");
+            txResult.TransactionResult.Error.ShouldContain($"exceeds limit");
 
             var str1 = Encoding.UTF8.GetString(new byte[10]);
             var message = new ProtobufMessage


### PR DESCRIPTION
Issue: #3559 