### PR TITLE
fix: resolve packaging failure issue

### DIFF
--- a/src/AElf.Kernel.Types/KernelConstants.cs
+++ b/src/AElf.Kernel.Types/KernelConstants.cs
@@ -5,7 +5,7 @@ namespace AElf.Kernel;
 
 public static class KernelConstants
 {
-    public const long ReferenceBlockValidPeriod = 64 * 8;
+    public const long ReferenceBlockValidPeriod = 64 * 16;
     public const int ProtocolVersion = 1;
     public const int DefaultRunnerCategory = 0;
     public const int CodeCoverageRunnerCategory = 30;


### PR DESCRIPTION
For issue https://github.com/AElfProject/AElf/issues/3617
- Changed ReferenceBlockValidPeriod from 64*8 to 64*16 to adjust the block validation period.