### PR TITLE
Transaction status result optimization

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           dotnet-version: '8.0'
       - name: Create temporary global.json
-        run: echo '{"sdk":{"version":"8.0.303"}}' > ./global.json
+        run: echo '{"sdk":{"version":"8.0.*"}}' > ./global.json
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:

--- a/protobuf/aelf/core.proto
+++ b/protobuf/aelf/core.proto
@@ -59,6 +59,8 @@ enum TransactionResultStatus {
     PENDING_VALIDATION = 5;
     // Transaction validation failed.
     NODE_VALIDATION_FAILED = 6;
+    // Transaction is expired and will never succeed
+    EXPIRED = 7;
 }
 
 message TransactionResult {

--- a/protobuf/aelf/core.proto
+++ b/protobuf/aelf/core.proto
@@ -59,8 +59,6 @@ enum TransactionResultStatus {
     PENDING_VALIDATION = 5;
     // Transaction validation failed.
     NODE_VALIDATION_FAILED = 6;
-    // Transaction is expired and will never succeed
-    EXPIRED = 7;
 }
 
 message TransactionResult {

--- a/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
+++ b/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
@@ -122,12 +122,11 @@ public class TransactionResultAppService : AElfAppService, ITransactionResultApp
         var chain = await _blockchainService.GetChainAsync();
         if (chain.BestChainHeight - output.Transaction.RefBlockNumber > KernelConstants.ReferenceBlockValidPeriod)
         {
-            output.Status = TransactionResultStatus.Expired.ToString().ToUpper();
-            output.Error = TransactionErrorResolver.TakeErrorMessage(TransactionResultStatus.Expired.ToString(),
-                _webAppOptions.IsDebugMode);
-            return output;
+                output.Status = TransactionResultStatus.Expired.ToString().ToUpper();
+                output.Error = TransactionErrorResolver.TakeErrorMessage(TransactionResultStatus.Expired.ToString(),
+                    _webAppOptions.IsDebugMode);
+                return output;
         }
-
         return output;
     }
 

--- a/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
+++ b/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
@@ -120,7 +120,8 @@ public class TransactionResultAppService : AElfAppService, ITransactionResultApp
         }
 
         var chain = await _blockchainService.GetChainAsync();
-        if (chain.BestChainHeight - output.Transaction.RefBlockNumber > KernelConstants.ReferenceBlockValidPeriod)
+        if (chain.BestChainHeight - output.Transaction.RefBlockNumber > KernelConstants.ReferenceBlockValidPeriod 
+            && transactionResult.Status == TransactionResultStatus.NotExisted)
         {
             // set a the Error message to the output to infer that the transaction will never succeed.
             var error = $"The transactions status is expired, and it will never succeed.";

--- a/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
+++ b/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
@@ -118,9 +118,16 @@ public class TransactionResultAppService : AElfAppService, ITransactionResultApp
                 return output;
             }
         }
-
-        return output;
         
+        switch (output.BlockNumber - output.Transaction.RefBlockNumber)
+        {
+            case > KernelConstants.ReferenceBlockValidPeriod:
+                output.Status = TransactionResultStatus.Expired.ToString().ToUpper();
+                output.Error = TransactionErrorResolver.TakeErrorMessage(TransactionResultStatus.Expired.ToString(), _webAppOptions.IsDebugMode);
+                return output;
+            default:
+                return output;
+        }
     }
 
     /// <summary>

--- a/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
+++ b/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
@@ -122,10 +122,10 @@ public class TransactionResultAppService : AElfAppService, ITransactionResultApp
         var chain = await _blockchainService.GetChainAsync();
         if (chain.BestChainHeight - output.Transaction.RefBlockNumber > KernelConstants.ReferenceBlockValidPeriod)
         {
-                output.Status = TransactionResultStatus.Expired.ToString().ToUpper();
-                output.Error = TransactionErrorResolver.TakeErrorMessage(TransactionResultStatus.Expired.ToString(),
-                    _webAppOptions.IsDebugMode);
-                return output;
+            // set a the Error message to the output to infer that the transaction will never succeed.
+            var error = $"The transactions status is:{TransactionResultStatus.Expired.ToString()}, and it will never succeed.";
+            output.Error = TransactionErrorResolver.TakeErrorMessage(error, _webAppOptions.IsDebugMode);
+            return output;    
         }
         return output;
     }

--- a/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
+++ b/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
@@ -124,9 +124,9 @@ public class TransactionResultAppService : AElfAppService, ITransactionResultApp
             && transactionResult.Status == TransactionResultStatus.NotExisted)
         {
             // set a the Error message to the output to infer that the transaction will never succeed.
-            var error = $"The transactions status is expired, and it will never succeed.";
+            var error = "The transaction is already expired, and it will never succeed.";
             output.Error = TransactionErrorResolver.TakeErrorMessage(error, _webAppOptions.IsDebugMode);
-            return output;    
+            return output;
         }
         return output;
     }

--- a/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
+++ b/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
@@ -123,7 +123,7 @@ public class TransactionResultAppService : AElfAppService, ITransactionResultApp
         if (chain.BestChainHeight - output.Transaction.RefBlockNumber > KernelConstants.ReferenceBlockValidPeriod)
         {
             // set a the Error message to the output to infer that the transaction will never succeed.
-            var error = $"The transactions status is:{TransactionResultStatus.Expired.ToString()}, and it will never succeed.";
+            var error = $"The transactions status is expired, and it will never succeed.";
             output.Error = TransactionErrorResolver.TakeErrorMessage(error, _webAppOptions.IsDebugMode);
             return output;    
         }

--- a/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
+++ b/src/AElf.WebApp.Application.Chain/Services/TransactionResultAppService.cs
@@ -118,16 +118,17 @@ public class TransactionResultAppService : AElfAppService, ITransactionResultApp
                 return output;
             }
         }
-        
-        switch (output.BlockNumber - output.Transaction.RefBlockNumber)
+
+        var chain = await _blockchainService.GetChainAsync();
+        if (chain.BestChainHeight - output.Transaction.RefBlockNumber > KernelConstants.ReferenceBlockValidPeriod)
         {
-            case > KernelConstants.ReferenceBlockValidPeriod:
-                output.Status = TransactionResultStatus.Expired.ToString().ToUpper();
-                output.Error = TransactionErrorResolver.TakeErrorMessage(TransactionResultStatus.Expired.ToString(), _webAppOptions.IsDebugMode);
-                return output;
-            default:
-                return output;
+            output.Status = TransactionResultStatus.Expired.ToString().ToUpper();
+            output.Error = TransactionErrorResolver.TakeErrorMessage(TransactionResultStatus.Expired.ToString(),
+                _webAppOptions.IsDebugMode);
+            return output;
         }
+
+        return output;
     }
 
     /// <summary>


### PR DESCRIPTION
set a the Error message to the output to infer that the transaction will never succeed. For issue #3623 