### PR TITLE
Extend seed NFT expiration time

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           dotnet-version: '8.0'
       - name: Create temporary global.json
-        run: echo '{"sdk":{"version":"8.0.303"}}' > ./global.json
+        run: echo '{"sdk":{"version":"8.0.*"}}' > ./global.json
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:

--- a/contract/AElf.Contracts.MultiToken/TokenContract_Actions.cs
+++ b/contract/AElf.Contracts.MultiToken/TokenContract_Actions.cs
@@ -697,8 +697,10 @@ public partial class TokenContract : TokenContractImplContainer.TokenContractImp
         Assert(tokenInfo != null, "Seed NFT does not exist.");
         Assert(tokenInfo.Owner == Context.Sender, "Sender is not Seed NFT owner.");
 
-        tokenInfo.ExternalInfo.Value["__seed_exp_time"] = input.ExpirationTime;
-        return base.ExtendSeedExpirationTime(input);
+        tokenInfo.ExternalInfo.Value[TokenContractConstants.SeedExpireTimeExternalInfoKey] = input.ExpirationTime.ToString();
+        State.TokenInfos[input.Symbol] = tokenInfo;
+        base.ExtendSeedExpirationTime(input);
+        return new Empty();
     }
 
     private int GetMaxBatchApproveCount()

--- a/contract/AElf.Contracts.MultiToken/TokenContract_Actions.cs
+++ b/contract/AElf.Contracts.MultiToken/TokenContract_Actions.cs
@@ -691,6 +691,16 @@ public partial class TokenContract : TokenContractImplContainer.TokenContractImp
         };
     }
 
+    public override Empty ExtendSeedExpirationTime(ExtendSeedExpirationTimeInput input)
+    {
+        var tokenInfo = GetTokenInfo(input.Symbol);
+        Assert(tokenInfo != null, "Seed NFT does not exist.");
+        Assert(tokenInfo.Owner == Context.Sender, "Sender is not Seed NFT owner.");
+
+        tokenInfo.ExternalInfo.Value["__seed_exp_time"] = input.ExpirationTime;
+        return base.ExtendSeedExpirationTime(input);
+    }
+
     private int GetMaxBatchApproveCount()
     {
         return State.MaxBatchApproveCount.Value == 0

--- a/protobuf/token_contract_impl.proto
+++ b/protobuf/token_contract_impl.proto
@@ -182,6 +182,9 @@ service TokenContractImpl {
     rpc GetMaxBatchApproveCount (google.protobuf.Empty) returns (google.protobuf.Int32Value) {
 
     }
+
+    rpc ExtendSeedExpirationTime (ExtendSeedExpirationTimeInput) returns (google.protobuf.Empty) {
+    }
 }
 
 message AdvanceResourceTokenInput {
@@ -444,4 +447,9 @@ message ModifyTokenIssuerAndOwnerInput {
 
 message SetTokenIssuerAndOwnerModificationEnabledInput{
     bool enabled = 1;
+}
+
+message ExtendSeedExpirationTimeInput {
+    string symbol = 1;
+    int64 expiration_time = 2;
 }

--- a/protobuf/token_contract_impl.proto
+++ b/protobuf/token_contract_impl.proto
@@ -453,3 +453,11 @@ message ExtendSeedExpirationTimeInput {
     string symbol = 1;
     int64 expiration_time = 2;
 }
+
+message SeedExpirationTimeUpdated {
+    option (aelf.is_event) = true;
+    int32 chain_id = 1;
+    string symbol = 2;
+    int64 old_expiration_time = 3;
+    int64 new_expiration_time = 4;
+}

--- a/test/AElf.Contracts.MultiToken.Tests/BVT/TokenApplicationTests.cs
+++ b/test/AElf.Contracts.MultiToken.Tests/BVT/TokenApplicationTests.cs
@@ -1893,4 +1893,15 @@ public partial class MultiTokenContractTests
         result.TransactionResult.Error.ShouldContain("Set token issuer and owner disabled.");
 
     }
+    
+    [Theory]
+    [InlineData("SEED-0", 1731927992000)]
+    public async Task ExtendSeedExpirationTime_Test(string symbol, long expirationTime)
+    {
+        ExtendSeedExpirationTimeInput input = new ExtendSeedExpirationTimeInput();
+        input.Symbol = symbol;
+        input.ExpirationTime = expirationTime;
+
+        await TokenContractStub.ExtendSeedExpirationTime.CallAsync(input);
+    }
 }

--- a/test/AElf.Contracts.MultiToken.Tests/MultiTokenContractTestBase.cs
+++ b/test/AElf.Contracts.MultiToken.Tests/MultiTokenContractTestBase.cs
@@ -240,4 +240,7 @@ public class MultiTokenContractTestBase : ContractTestBase<MultiTokenContractTes
         await CreateSeedNftAsync(stub, createInput);
         return await stub.Create.SendWithExceptionAsync(createInput);
     }
+    
+    
+    
 }


### PR DESCRIPTION
Ability to allow the owner of the SEED Collection to extend the expiration time for the specified SEED NFT. For issue #3622 